### PR TITLE
Default storage location to `~/.gradle/caches/gradle-jdks`

### DIFF
--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -14,16 +14,21 @@ import java.nio.file.StandardCopyOption;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.gradle.api.Project;
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.provider.Provider;
 
 public final class JdkManager {
     private final Project project;
-    private final Path storageLocation;
+    private final Provider<Directory> storageLocation;
     private final JdkDistributions jdkDistributions;
     private final JdkDownloaders jdkDownloaders;
 
     JdkManager(
-            Project project, Path storageLocation, JdkDistributions jdkDistributions, JdkDownloaders jdkDownloaders) {
+            Project project,
+            Provider<Directory> storageLocation,
+            JdkDistributions jdkDistributions,
+            JdkDownloaders jdkDownloaders) {
         this.project = project;
         this.storageLocation = storageLocation;
         this.jdkDistributions = jdkDistributions;
@@ -31,8 +36,13 @@ public final class JdkManager {
     }
 
     public Path jdk(JdkSpec jdkSpec) {
-        Path diskPath = storageLocation.resolve(String.format(
-                "%s-%s-%s", jdkSpec.distributionName(), jdkSpec.release().version(), jdkSpec.consistentShortHash()));
+        Path diskPath = storageLocation
+                .get()
+                .getAsFile()
+                .toPath()
+                .resolve(String.format(
+                        "%s-%s-%s",
+                        jdkSpec.distributionName(), jdkSpec.release().version(), jdkSpec.consistentShortHash()));
 
         if (Files.exists(diskPath)) {
             return diskPath;

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksExtension.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksExtension.java
@@ -8,6 +8,7 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import javax.inject.Inject;
 import org.gradle.api.Action;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.ProviderFactory;
@@ -17,6 +18,8 @@ public abstract class JdksExtension {
     protected abstract MapProperty<JdkDistributionName, JdkDistributionExtension> getJdkDistributions();
 
     protected abstract MapProperty<JavaLanguageVersion, JdkExtension> getJdks();
+
+    public abstract DirectoryProperty getJdkStorageLocation();
 
     @Inject
     protected abstract ProviderFactory getProviderFactory();

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksPlugin.java
@@ -6,6 +6,7 @@ package com.palantir.gradle.jdks;
 
 import com.palantir.baseline.extensions.BaselineJavaVersionsExtension;
 import com.palantir.baseline.plugins.BaselineJavaVersions;
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -28,13 +29,7 @@ public final class JdksPlugin implements Plugin<Project> {
 
         JdkManager jdkManager = new JdkManager(
                 rootProject.getProject(),
-                rootProject
-                        .getLayout()
-                        .getBuildDirectory()
-                        .dir("jdks")
-                        .get()
-                        .getAsFile()
-                        .toPath(),
+                jdksExtension.getJdkStorageLocation(),
                 jdkDistributions,
                 new JdkDownloaders(rootProject, jdksExtension));
 
@@ -59,6 +54,13 @@ public final class JdksPlugin implements Plugin<Project> {
 
     private JdksExtension extension(Project rootProject, JdkDistributions jdkDistributions) {
         JdksExtension jdksExtension = rootProject.getExtensions().create("jdks", JdksExtension.class);
+
+        jdksExtension
+                .getJdkStorageLocation()
+                .set(rootProject
+                        .getLayout()
+                        .dir(rootProject.provider(
+                                () -> new File(System.getProperty("user.home"), ".gradle/caches/gradle-jdks"))));
 
         Arrays.stream(JdkDistributionName.values()).forEach(jdkDistributionName -> {
             JdkDistributionExtension jdkDistributionExtension =

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
@@ -19,12 +19,17 @@ class JdksPluginIntegrationSpec extends IntegrationSpec {
                     distribution = 'azul-zulu'
                     jdkVersion = '11.54.25-11.0.14.1'    
                 }
+            
+                jdkStorageLocation = layout.buildDirectory.dir('jdks')
             }
             
             javaVersions {
                 libraryTarget = 11
             }
-            
+        '''.stripIndent(true)
+
+        // language=gradle
+        def subprojectDir = addSubproject 'subproject', '''
             apply plugin: 'java-library'
             
             task printJavaVersion(type: JavaExec) {
@@ -41,21 +46,18 @@ class JdksPluginIntegrationSpec extends IntegrationSpec {
 
             public final class PrintJavaVersion {
                 public static void main(String... args) {
-                    System.out.println(String.format(
-                            "version: %s, vendor: %s",
+                    System.out.printf(
+                            "version: %s, vendor: %s%n",
                             System.getProperty("java.version"),
-                            System.getProperty("java.vendor")));
+                            System.getProperty("java.vendor"));
                 }
             }
-        '''.stripIndent(true)
+        '''.stripIndent(true), subprojectDir
 
         when:
-
-        def stdout = runTasksSuccessfully(
-                'printJavaVersion',
-                // TODO: avoid resolving from root configuration somehow, removed in Gradle 8
-                '--warning-mode=none')
-                .standardOutput
+        def result = runTasksSuccessfully('printJavaVersion', '--warning-mode=all')
+        println result.standardError
+        def stdout = result.standardOutput
 
         then:
         stdout.contains 'version: 11.0.14.1, vendor: Azul Systems, Inc.'

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
@@ -67,9 +67,7 @@ class JdksPluginIntegrationSpec extends IntegrationSpec {
         '''.stripIndent(true), subprojectDir
 
         when:
-        def result = runTasksSuccessfully('printJavaVersion', '--warning-mode=all')
-        println result.standardError
-        def stdout = result.standardOutput
+        def stdout = runTasksSuccessfully('printJavaVersion').standardOutput
 
         then:
         stdout.contains 'version: 11.0.14.1, vendor: Azul Systems, Inc.'


### PR DESCRIPTION
## Before this PR
We saved the JDKs to `build/jdks` mainly so that these were easier to investigate while testing.

## After this PR
We save JDKs in `~/.gradle/caches/gradle-jdks`.

This means extracted JDKs can be shared between directories. 
Using this directory because we already cache `~/.gradle/caches` in most of our circle builds.

In tests we override it back to `build/jdks` so we actually exercise the codepaths we expect/better isolation.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
