### PR TITLE
Fix publishing

### DIFF
--- a/changelog/@unreleased/pr-15.v2.yml
+++ b/changelog/@unreleased/pr-15.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix publishing
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/15

--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'groovy'
+apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.external-publish-gradle-plugin'
 
 dependencies {
@@ -21,6 +22,13 @@ gradlePlugin {
             implementationClass = 'com.palantir.gradle.jdks.JdksPlugin'
         }
     }
+}
+
+pluginBundle {
+    website = 'https://github.com/palantir/gradle-jdks'
+    vcsUrl = 'https://github.com/palantir/gradle-jdks'
+    description = 'Download specific JDKs versions automatically'
+    tags = ['java', 'jdks']
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
## Before this PR
We do not publish to maven central for the gradle plugin

The gradle plugin fails to publish with errors

## After this PR
==COMMIT_MSG==
Fix publishing
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
