### PR TITLE
Fix Zulu version stringly typing

### DIFF
--- a/changelog/@unreleased/pr-17.v2.yml
+++ b/changelog/@unreleased/pr-17.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix `ZuluVersionUtils` encoding the version wrongly.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/17

--- a/gradle-jdks-distributions/src/test/java/com/palantir/gradle/jdks/ZuluVersionUtilsTest.java
+++ b/gradle-jdks-distributions/src/test/java/com/palantir/gradle/jdks/ZuluVersionUtilsTest.java
@@ -16,10 +16,13 @@
 
 package com.palantir.gradle.jdks;
 
-public final class ZuluVersionUtils {
-    public static String combineZuluVersions(String zuluVersion, String javaVersion) {
-        return zuluVersion + "-" + javaVersion;
-    }
+import static org.assertj.core.api.Assertions.assertThat;
 
-    private ZuluVersionUtils() {}
+import org.junit.jupiter.api.Test;
+
+class ZuluVersionUtilsTest {
+    @Test
+    void ensure_version_is_encoded_properly() {
+        assertThat(ZuluVersionUtils.combineZuluVersions("11.33.55", "11.0.4")).isEqualTo("11.33.55-11.0.4");
+    }
 }

--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     annotationProcessor 'org.immutables:value'
 
     testImplementation 'com.netflix.nebula:nebula-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.assertj:assertj-core'
 }
 
 gradlePlugin {

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
@@ -16,10 +16,17 @@
 
 package com.palantir.gradle.jdks;
 
-public final class ZuluVersionUtils {
-    public static String combineZuluVersions(String zuluVersion, String javaVersion) {
-        return zuluVersion + "-" + javaVersion;
-    }
+import static org.assertj.core.api.Assertions.assertThat;
 
-    private ZuluVersionUtils() {}
+import com.palantir.gradle.jdks.AzulZuluJdkDistribution.ZuluVersionSplit;
+import org.junit.jupiter.api.Test;
+
+class AzulZuluJdkDistributionTest {
+    @Test
+    void zulu_version_combination_survives_roundtrip() {
+        ZuluVersionSplit versionSplit = AzulZuluJdkDistribution.splitCombinedVersion(
+                ZuluVersionUtils.combineZuluVersions("11.22.33", "11.0.1"));
+        assertThat(versionSplit.javaVersion()).isEqualTo("11.0.1");
+        assertThat(versionSplit.zuluVersion()).isEqualTo("11.22.33");
+    }
 }


### PR DESCRIPTION
## Before this PR
The different pieces of code that combined then split zulu versions was not correct 🤦🏻 

## After this PR
==COMMIT_MSG==
It is fixed.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
