### PR TITLE
Expose :gradle-jdks-distributions as api

### DIFF
--- a/changelog/@unreleased/pr-26.v2.yml
+++ b/changelog/@unreleased/pr-26.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Expose `gradle-jdks-distributions` as api in `gradle-jdks`.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/26

--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -4,7 +4,8 @@ apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.external-publish-gradle-plugin'
 
 dependencies {
-    implementation project(':gradle-jdks-distributions')
+    api project(':gradle-jdks-distributions')
+
     implementation 'com.palantir.baseline:gradle-baseline-java'
 
     compileOnly 'org.immutables:value::annotations'


### PR DESCRIPTION
## Before this PR
Can't use the `jdkDistribution(JdkDistributionName ....` method as `JdkDistributionName` is not exposed as API.

## After this PR
==COMMIT_MSG==
Expose `gradle-jdks-distributions` as api in `gradle-jdks`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
