### PR TITLE
Do not use atomic move to move jdks

### DIFF
--- a/changelog/@unreleased/pr-29.v2.yml
+++ b/changelog/@unreleased/pr-29.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'Do not atomically move the java home directory to avoid `Could not
+    move java home: Directory not empty` exceptions'
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/29

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -25,7 +25,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.gradle.api.Project;
@@ -78,7 +77,7 @@ public final class JdkManager {
             });
 
             try {
-                Files.move(javaHome, diskPath, StandardCopyOption.ATOMIC_MOVE);
+                Files.move(javaHome, diskPath);
             } catch (FileAlreadyExistsException e) {
                 // This means another process has successfully installed this JDK, and we can just use their one.
                 return diskPath;


### PR DESCRIPTION
## Before this PR
Tried this out on some very large projects internally. Kept getting this kinds of errors:

```
Caused by: java.lang.RuntimeException: Could not move java home
Caused by: java.nio.file.FileSystemException: /Users/callumr/.gradle/caches/gradle-jdks/azul-zulu-15.40.19-15.0.7-b7ed6f7c59131899.in-progress-c5b252e4/zulu15.40.19-ca-jdk15.0.7-macosx_aarch64/zulu-15.jdk/Contents/Home -> /Users/callumr/.gradle/caches/gradle-jdks/azul-zulu-15.40.19-15.0.7-b7ed6f7c59131899: Directory not empty
        at com.palantir.gradle.jdks.JdkManager.jdk(JdkManager.java:81)
        at com.palantir.gradle.jdks.JdksPlugin.lambda$javaInstallationForLanguageVersion$5(JdksPlugin.java:86)
```

It seems when you try to move a directory using `ATOMIC_MOVE` and the target directory exists, it fails with a `FileSystemException` with a message `Directory not empty`.  Not a `FileAlreadyExistsException` or `DirectoryNotEmptyException`. At least on macos.

Additionally, the docs for `ATOMIC_MOVE` are a little scary:

> If the target file exists then it is implementation specific if the existing file is replaced or this method fails by throwing an IOException.

😨 😨 😨 

## After this PR
==COMMIT_MSG==
Do not atomically move the java home directory to avoid `Could not move java home: Directory not empty` exceptions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
