### PR TITLE
Fix CME in JdkDownloaders

### DIFF
--- a/changelog/@unreleased/pr-39.v2.yml
+++ b/changelog/@unreleased/pr-39.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix `ConcurrentModificationException` from `JdkDownloaders`.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/39

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkDownloaders.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkDownloaders.java
@@ -16,13 +16,13 @@
 
 package com.palantir.gradle.jdks;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.gradle.api.Project;
 import org.immutables.value.Value;
 
 final class JdkDownloaders {
-    private final Map<JdkDownloadersCacheKey, JdkDownloader> jdkDownloaders = new HashMap<>();
+    private final ConcurrentMap<JdkDownloadersCacheKey, JdkDownloader> jdkDownloaders = new ConcurrentHashMap<>();
 
     private final JdksExtension jdksExtension;
 


### PR DESCRIPTION
## Before this PR
Once again I failed to clock that `JdkDownloaders` is accessed by multiple threads. There is a CME that happens here:

```
Caused by: java.util.ConcurrentModificationException: (No message provided)
        at com.palantir.gradle.jdks.JdkDownloaders.jdkDownloaderFor(JdkDownloaders.java:34)
        at com.palantir.gradle.jdks.JdkManager.jdk(JdkManager.java:62)
        at com.palantir.gradle.jdks.JdksPlugin.lambda$javaInstallationForLanguageVersion$5(JdksPlugin.java:86)
```

## After this PR
==COMMIT_MSG==
Fix `ConcurrentModificationException` from `JdkDownloaders`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
