### PR TITLE
Add x86_64 to arch list

### DIFF
--- a/changelog/@unreleased/pr-40.v2.yml
+++ b/changelog/@unreleased/pr-40.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Prevent `Cannot get architecture for x86_64` errors on macos.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/40

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkRelease.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkRelease.java
@@ -32,7 +32,7 @@ interface JdkRelease {
     default Arch arch() {
         String osArch = System.getProperty("os.arch");
 
-        if (Set.of("x64", "amd64").contains(osArch)) {
+        if (Set.of("x86_64", "x64", "amd64").contains(osArch)) {
             return Arch.X86_64;
         }
 

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkRelease.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkRelease.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.jdks;
 
+import java.util.Locale;
 import java.util.Set;
 import org.immutables.value.Value;
 
@@ -30,7 +31,7 @@ interface JdkRelease {
 
     @Value.Default
     default Arch arch() {
-        String osArch = System.getProperty("os.arch");
+        String osArch = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
 
         if (Set.of("x86_64", "x64", "amd64").contains(osArch)) {
             return Arch.X86_64;


### PR DESCRIPTION
## Before this PR
Missed out `x86_64` arch string for macos.

## After this PR
==COMMIT_MSG==
Prevent `Cannot get architecture for x86_64` errors on macos.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
