### PR TITLE
The Azul JDK distribution uses tar.gz everywhere except windows

### DIFF
--- a/changelog/@unreleased/pr-41.v2.yml
+++ b/changelog/@unreleased/pr-41.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The Azul JDK distribution uses tar.gz everywhere except windows, matching
+    available distributions from the Azul CDN
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/41

--- a/changelog/@unreleased/pr-41.v2.yml
+++ b/changelog/@unreleased/pr-41.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: The Azul JDK distribution uses tar.gz everywhere except windows, matching
     available distributions from the Azul CDN
   links:

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
@@ -37,7 +37,10 @@ final class AzulZuluJdkDistribution implements JdkDistribution {
                 os(jdkRelease.os()),
                 arch(jdkRelease.arch()));
 
-        return JdkPath.builder().filename(filename).extension(Extension.ZIP).build();
+        return JdkPath.builder()
+                .filename(filename)
+                .extension(extension(jdkRelease.os()))
+                .build();
     }
 
     private static String os(Os os) {
@@ -64,6 +67,18 @@ final class AzulZuluJdkDistribution implements JdkDistribution {
         }
 
         throw new UnsupportedOperationException("Case " + arch + " not implemented");
+    }
+
+    private static Extension extension(Os operatingSystem) {
+        switch (operatingSystem) {
+            case MACOS:
+                // fall-through
+            case LINUX:
+                return Extension.TARGZ;
+            case WINDOWS:
+                return Extension.ZIP;
+        }
+        throw new IllegalArgumentException("Unknown OS: " + operatingSystem);
     }
 
     static ZuluVersionSplit splitCombinedVersion(String combinedVersion) {

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
@@ -78,7 +78,7 @@ final class AzulZuluJdkDistribution implements JdkDistribution {
             case WINDOWS:
                 return Extension.ZIP;
         }
-        throw new IllegalArgumentException("Unknown OS: " + operatingSystem);
+        throw new UnsupportedOperationException("Unknown OS: " + operatingSystem);
     }
 
     static ZuluVersionSplit splitCombinedVersion(String combinedVersion) {

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
@@ -29,4 +29,30 @@ class AzulZuluJdkDistributionTest {
         assertThat(versionSplit.javaVersion()).isEqualTo("11.0.1");
         assertThat(versionSplit.zuluVersion()).isEqualTo("11.22.33");
     }
+
+    @Test
+    void jdk_path_linux_x86_64() {
+        AzulZuluJdkDistribution distribution = new AzulZuluJdkDistribution();
+        String version = ZuluVersionUtils.combineZuluVersions("11.56.19", "11.0.15");
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(JdkRelease.Arch.X86_64)
+                .os(Os.LINUX)
+                .version(version)
+                .build());
+        assertThat(path.filename()).isEqualTo("zulu11.56.19-ca-jdk11.0.15-linux_x64");
+        assertThat(path.extension()).isEqualTo(JdkPath.Extension.TARGZ);
+    }
+
+    @Test
+    void jdk_path_windows_x86_64() {
+        AzulZuluJdkDistribution distribution = new AzulZuluJdkDistribution();
+        String version = ZuluVersionUtils.combineZuluVersions("11.56.19", "11.0.15");
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(JdkRelease.Arch.X86_64)
+                .os(Os.WINDOWS)
+                .version(version)
+                .build());
+        assertThat(path.filename()).isEqualTo("zulu11.56.19-ca-jdk11.0.15-win_x64");
+        assertThat(path.extension()).isEqualTo(JdkPath.Extension.ZIP);
+    }
 }


### PR DESCRIPTION
==COMMIT_MSG==
The Azul JDK distribution uses tar.gz everywhere except windows, matching available distributions from the Azul CDN
==COMMIT_MSG==
