### PR TITLE
Don't allow baseline-java-versions to be configured multiple times

### DIFF
--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksPlugin.java
@@ -38,7 +38,9 @@ public final class JdksPlugin implements Plugin<Project> {
         JdkManager jdkManager = new JdkManager(
                 jdksExtension.getJdkStorageLocation(), jdkDistributions, new JdkDownloaders(jdksExtension));
 
-        rootProject.getPluginManager().apply(BaselineJavaVersions.class);
+        if (!rootProject.getPluginManager().hasPlugin("com.palantir.baseline-java-versions")) {
+            rootProject.getPluginManager().apply(BaselineJavaVersions.class);
+        }
 
         rootProject
                 .getExtensions()


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

I work in a large monorepo, where occasionally indirectly including this plugin (transitively through another plugin) causes the BaselineJavaVersions plugin to be applied more than once. This isn't safe to do, so attempt to add a check that at least minimizes this potential edge case.

## After this PR
==COMMIT_MSG==
Don't allow baseline-java-versions to be configured multiple times
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
