### PR TITLE
Handle older glibc in libc autodetection

### DIFF
--- a/changelog/@unreleased/pr-55.v2.yml
+++ b/changelog/@unreleased/pr-55.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handler older glibc in libc autodetection
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/55

--- a/changelog/@unreleased/pr-55.v2.yml
+++ b/changelog/@unreleased/pr-55.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Handler older glibc in libc autodetection
+  description: Handle older glibc in libc autodetection
   links:
   - https://github.com/palantir/gradle-jdks/pull/55

--- a/gradle-jdks/src/integTest/java/com/palantir/gradle/jdks/OsTest.java
+++ b/gradle-jdks/src/integTest/java/com/palantir/gradle/jdks/OsTest.java
@@ -26,8 +26,13 @@ import org.junit.jupiter.api.Test;
 
 class OsTest {
     @Test
-    void glibc_system_is_identified() {
+    void modern_glibc_system_is_identified() {
         assertThat(Os.linuxLibcFromLdd(execInDocker("ubuntu:20.04"))).isEqualTo(Os.LINUX_GLIBC);
+    }
+
+    @Test
+    void old_glibc_system_is_identified() {
+        assertThat(Os.linuxLibcFromLdd(execInDocker("centos:7"))).isEqualTo(Os.LINUX_GLIBC);
     }
 
     @Test

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/Os.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/Os.java
@@ -78,7 +78,7 @@ enum Os {
                         "ldd failed to run within " + secondsToWait + " seconds. Output: " + lowercaseOutput);
             }
 
-            if (lowercaseOutput.contains("glibc")) {
+            if (lowercaseOutput.contains("glibc") || lowercaseOutput.contains("gnu libc")) {
                 return Os.LINUX_GLIBC;
             }
 


### PR DESCRIPTION
## Before this PR
Running this project on centos 7 gives the following error:

```
java.lang.UnsupportedOperationException: Cannot work out libc used by this OS. ldd output was: ldd (gnu libc) 2.17
copyright (c) 2012 free software foundation, inc.
this is free software; see the source for copying conditions.  there is no
warranty; not even for merchantability or fitness for a particular purpose.
written by roland mcgrath and ulrich drepper.
```

## After this PR
==COMMIT_MSG==
Handler older glibc in libc autodetection
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
