### PR TITLE
Do not put jdks in ~/.gradle/caches

### DIFF
--- a/changelog/@unreleased/pr-56.v2.yml
+++ b/changelog/@unreleased/pr-56.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Move default JDK storage location from `~/.gradle/caches/gradle-jdks`
+    to `~/.gradle/gradle-jdks` to avoid caching the same data twice in CI.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/56

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksPlugin.java
@@ -57,7 +57,7 @@ public final class JdksPlugin implements Plugin<Project> {
                 .set(rootProject
                         .getLayout()
                         .dir(rootProject.provider(
-                                () -> new File(System.getProperty("user.home"), ".gradle/caches/gradle-jdks"))));
+                                () -> new File(System.getProperty("user.home"), ".gradle/gradle-jdks"))));
 
         Arrays.stream(JdkDistributionName.values()).forEach(jdkDistributionName -> {
             jdksExtension.jdkDistribution(jdkDistributionName, jdkDistributionExtension -> {


### PR DESCRIPTION
## Before this PR
We currently store JDKs in `~/.gradle/caches`:

```console
~{0} $ tree -L 1 .gradle/caches/gradle-jdks/
.gradle/caches/gradle-jdks/
├── azul-zulu-11.56.19-11.0.15-61732a249c934c52
└── azul-zulu-17.34.19-17.0.3-a3ceab47882436a6
```

This was originally so that we could easily cache the extracted JDKs in circle, however this is actually more problematic than useful.

Each compressed JDK is already stored elsewhere in `~/.gradle/caches` by gradle. By also storing the extracted JDK in `/.gradle/caches`, a circle job that does `save_cache` or `restore_cache` on `~/.gradle/caches` will need to (de)compress and transport over the network the same bytes again. I've noticed that caching takes quite a bit longer for internal projects, as when using 3 JDKS they need to save/restore an extra ~1Gb of data. Considering it takes ~1 second to extract each JDK on CI, it makes sense to just not cache the extract JDKs.

## After this PR
==COMMIT_MSG==
Move default JDK storage location from `~/.gradle/caches/gradle-jdks` to `~/.gradle/gradle-jdks` to avoid caching the same data twice in CI.
==COMMIT_MSG==

## Possible downsides?
Devs will have two directories on their laptops - one with `~/.gradle/caches/gradle-jdks`, one with `~/.gradle/gradle-jdks` if they have used this plugin before this change.