### PR TITLE
Add better support for Windows

### DIFF
--- a/changelog/@unreleased/pr-68.v2.yml
+++ b/changelog/@unreleased/pr-68.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed an issue preventing this plugin from working on Windows.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/68

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -109,7 +109,7 @@ public final class JdkManager {
             return files.filter(file -> Files.isRegularFile(file)
                             // macos JDKs have a `bin/java` symlink to `Contents/Home/bin/java`
                             && !Files.isSymbolicLink(file)
-                            && file.endsWith(Paths.get("bin/java")))
+                            && file.endsWith(Paths.get("bin/" + SystemTools.java())))
                     .findFirst()
                     // JAVA_HOME/bin/java
                     .orElseThrow(() -> new RuntimeException("Failed to find java home in " + temporaryJdkPath))
@@ -127,7 +127,7 @@ public final class JdkManager {
 
         ExecResult keytoolResult = project.exec(exec -> {
             exec.setCommandLine(
-                    "bin/keytool",
+                    "bin/" + SystemTools.keytool(),
                     "-import",
                     "-trustcacerts",
                     "-alias",

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -109,7 +109,7 @@ public final class JdkManager {
             return files.filter(file -> Files.isRegularFile(file)
                             // macos JDKs have a `bin/java` symlink to `Contents/Home/bin/java`
                             && !Files.isSymbolicLink(file)
-                            && file.endsWith(Paths.get("bin/" + SystemTools.java())))
+                            && file.endsWith(Paths.get("bin", SystemTools.java())))
                     .findFirst()
                     // JAVA_HOME/bin/java
                     .orElseThrow(() -> new RuntimeException("Failed to find java home in " + temporaryJdkPath))
@@ -127,7 +127,7 @@ public final class JdkManager {
 
         ExecResult keytoolResult = project.exec(exec -> {
             exec.setCommandLine(
-                    "bin/" + SystemTools.keytool(),
+                    Paths.get("bin", SystemTools.keytool()).toString(),
                     "-import",
                     "-trustcacerts",
                     "-alias",

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/SystemTools.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/SystemTools.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+final class SystemTools {
+    private SystemTools() {}
+
+    static String java() {
+        if (Os.current() == Os.WINDOWS) {
+            return "java.exe";
+        }
+        return "java";
+    }
+
+    static String keytool() {
+        if (Os.current() == Os.WINDOWS) {
+            return "keytool.exe";
+        }
+        return "keytool";
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

`java` doesn't exist on windows, it's `java.exe`. So this plugin fails on Windows.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed an issue preventing this plugin from working on Windows.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

