### PR TITLE
Attempt to move unpacked JDKs into place more safely

### DIFF
--- a/changelog/@unreleased/pr-71.v2.yml
+++ b/changelog/@unreleased/pr-71.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Attempt to move unpacked JDKs into place more safely with replace-existing
+    and an attempted atomic move
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/71


### PR DESCRIPTION
==COMMIT_MSG==
Attempt to move unpacked JDKs into place more safely with replace-existing and an attempted atomic move
==COMMIT_MSG==
