### PR TITLE
Lock jdk creation using file locks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.baseline-java-versions'
 apply plugin: 'com.palantir.jdks.latest'
 
+javaVersions {
+    libraryTarget = 11
+    runtime = 17
+}
+
 version gitVersion()
 
 allprojects {
@@ -39,9 +44,3 @@ allprojects {
     apply plugin: 'org.inferred.processors'
     apply plugin: 'com.palantir.java-format'
 }
-
-javaVersions {
-    libraryTarget = 11
-    runtime = 17
-}
-

--- a/changelog/@unreleased/pr-73.v2.yml
+++ b/changelog/@unreleased/pr-73.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Lock jdk creation using file locks
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/73

--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     implementation 'com.palantir.baseline:gradle-baseline-java'
     implementation 'com.palantir.gradle.utils:lazily-configured-mapping'
+    implementation 'com.google.guava:guava'
 
     compileOnly 'org.immutables:value::annotations'
     annotationProcessor 'org.immutables:value'

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -16,10 +16,15 @@
 
 package com.palantir.gradle.jdks;
 
+import com.google.common.io.Closer;
+import com.google.common.util.concurrent.Striped;
 import com.palantir.gradle.jdks.JdkPath.Extension;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
@@ -27,7 +32,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.UUID;
+import java.util.concurrent.locks.Lock;
 import java.util.stream.Stream;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -36,6 +43,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.process.ExecResult;
 
 public final class JdkManager {
+
     private final Provider<Directory> storageLocation;
     private final JdkDistributions jdkDistributions;
     private final JdkDownloaders jdkDownloaders;
@@ -64,9 +72,10 @@ public final class JdkManager {
                 .jdkDownloaderFor(project, jdkSpec.distributionName())
                 .downloadJdkPath(jdkPath);
 
-        Path temporaryJdkPath = Paths.get(
-                diskPath + ".in-progress-" + UUID.randomUUID().toString().substring(0, 8));
-        try {
+        Path temporaryJdkPath = diskPath.getParent()
+                .resolve(diskPath.getFileName() + ".in-progress-"
+                        + UUID.randomUUID().toString().substring(0, 8));
+        try (PathLock ignored = new PathLock(diskPath)) {
             project.copy(copy -> {
                 copy.from(unpackTree(project, jdkPath.extension(), jdkArchive));
                 copy.into(temporaryJdkPath);
@@ -80,6 +89,8 @@ public final class JdkManager {
 
             moveJavaHome(javaHome, diskPath);
             return diskPath;
+        } catch (IOException e) {
+            throw new RuntimeException("Locking failed", e);
         } finally {
             project.delete(delete -> {
                 delete.delete(temporaryJdkPath.toFile());
@@ -169,6 +180,42 @@ public final class JdkManager {
             throw new RuntimeException(String.format(
                     "Failed to add ca cert '%s' to java installation at '%s'. Keytool output: %s\n\n",
                     alias, javaHome, output.toString(StandardCharsets.UTF_8)));
+        }
+    }
+
+    /**
+     * Abstraction around locking access to a file or directory, by creating another file with a
+     * matching name, and '.lock' extension. Note that the underlying file locking mechanism is
+     * left to the filesystem, so we must be careful to work within its bounds. For example,
+     * POSIX file locks apply to a process, so within the process we must ensure synchronization
+     * separately.
+     */
+    private static final class PathLock implements Closeable {
+        private static final Striped<Lock> JVM_LOCKS = Striped.lock(16);
+        private final Closer closer;
+
+        PathLock(Path path) throws IOException {
+            this.closer = Closer.create();
+            try {
+                Lock jvmLock = JVM_LOCKS.get(path);
+                jvmLock.lock();
+                closer.register(jvmLock::unlock);
+                Files.createDirectories(path.getParent());
+                FileChannel channel = closer.register(FileChannel.open(
+                        path.getParent().resolve(path.getFileName() + ".lock"),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE));
+                FileLock fileLock = channel.lock();
+                closer.register(fileLock::close);
+            } catch (Throwable t) {
+                closer.close();
+                throw t;
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            closer.close();
         }
     }
 }


### PR DESCRIPTION
Previously concurrent requests for JDKs would result in parallel unpacks which fail in unexpected ways due to serial existence checks succeeding in parallel.

Unfortunately this is difficult to test.

==COMMIT_MSG==
Lock jdk creation using file locks
==COMMIT_MSG==

We'll leave around `<jdk-dir-name>.lock` files in the jdks directory

