### PR TITLE
JdkManager double-checks the target location once a lock is held

### DIFF
--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -96,6 +96,16 @@ public final class JdkManager {
                 .resolve(diskPath.getFileName() + ".in-progress-"
                         + UUID.randomUUID().toString().substring(0, 8));
         try (PathLock ignored = new PathLock(diskPath)) {
+            // double-check, now that we hold the lock
+            if (Files.exists(diskPath)) {
+                project.getLogger()
+                        .info(
+                                "JDK {} {} ({}) was installed while this task waited for the lock",
+                                jdkSpec.distributionName(),
+                                jdkSpec.release().version(),
+                                jdkSpec.consistentShortHash());
+                return diskPath;
+            }
             project.getLogger()
                     .info(
                             "Unpacking JDK {} {} ({}) into {}",


### PR DESCRIPTION
Overwriting one non-empty directory with another doesn't work. Once the lock is held, we must check again whether the target location exists.
==COMMIT_MSG==
JdkManager double-checks the target location once a lock is held
==COMMIT_MSG==

