### PR TITLE
Support Zulu bundle flags

### DIFF
--- a/changelog/@unreleased/pr-86.v2.yml
+++ b/changelog/@unreleased/pr-86.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support Zulu bundle flags
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/86

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
@@ -105,7 +105,7 @@ final class AzulZuluJdkDistribution implements JdkDistribution {
 
         if (endOfFlags == split.size()) {
             throw new IllegalArgumentException(
-                    String.format("Expected %s to split into two versions, split into one."));
+                    String.format("Expected %s to split into two versions, split into one.", combinedVersion));
         }
 
         return ZuluVersionSplit.builder()

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
@@ -33,6 +33,14 @@ class AzulZuluJdkDistributionTest {
     }
 
     @Test
+    void zulu_version_combination_supports_bundle_flags() {
+        ZuluVersionSplit versionSplit = AzulZuluJdkDistribution.splitCombinedVersion(
+                ZuluVersionUtils.combineZuluVersions("19.0.21-ea", "19.0.0-ea.6"));
+        assertThat(versionSplit.zuluVersion()).isEqualTo("19.0.21-ea");
+        assertThat(versionSplit.javaVersion()).isEqualTo("19.0.0-ea.6");
+    }
+
+    @Test
     void jdk_path_linux_x86_64() {
         AzulZuluJdkDistribution distribution = new AzulZuluJdkDistribution();
         String version = ZuluVersionUtils.combineZuluVersions("11.56.19", "11.0.15");


### PR DESCRIPTION
Some Zulu distributions come with extra flags. I care about EA builds,
but there are other flags, which currently fail the string.split test.

This PR attempts to handle these flags on the Zulu part of the version
string. The Java version string can also contain -ea, but I assume the
'rest' of the string is the Java version string.

## Before this PR
JDK version `19.0.21-ea-19.0.0-ea.6` fails.

## After this PR
JDK version `19.0.21-ea-19.0.0-ea.6` passes.

## Possible downsides?
This PR assumes that the rest of the string is the java version. So e.g. '19.0.21-ea-THIS!IS-NOT!A!VERSION!' would pass. This is similar behaviour to as present since the non-sensical openjdk version could just as easily be '19.0.21-ea-THIS!IS!NOT!A!VERSION' which would have passed prior to this PR.
