### PR TITLE
Omit the availability specifier if the user specified it

### DIFF
--- a/changelog/@unreleased/pr-88.v2.yml
+++ b/changelog/@unreleased/pr-88.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Omit the availability specifier if the user specified it. This enables
+    specification of ea versions.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/88

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
@@ -35,8 +35,8 @@ class AzulZuluJdkDistributionTest {
     @Test
     void zulu_version_combination_supports_bundle_flags() {
         ZuluVersionSplit versionSplit = AzulZuluJdkDistribution.splitCombinedVersion(
-                ZuluVersionUtils.combineZuluVersions("19.0.21-ea", "19.0.0-ea.6"));
-        assertThat(versionSplit.zuluVersion()).isEqualTo("19.0.21-ea");
+                ZuluVersionUtils.combineZuluVersions("19.0.21-cp1-ea", "19.0.0-ea.6"));
+        assertThat(versionSplit.zuluVersion()).isEqualTo("19.0.21-cp1-ea");
         assertThat(versionSplit.javaVersion()).isEqualTo("19.0.0-ea.6");
     }
 
@@ -50,6 +50,19 @@ class AzulZuluJdkDistributionTest {
                 .version(version)
                 .build());
         assertThat(path.filename()).isEqualTo("zulu11.56.19-ca-jdk11.0.15-linux_x64");
+        assertThat(path.extension()).isEqualTo(Extension.TARGZ);
+    }
+
+    @Test
+    void jdk_path_linux_x86_64_early_access() {
+        AzulZuluJdkDistribution distribution = new AzulZuluJdkDistribution();
+        String version = ZuluVersionUtils.combineZuluVersions("19.0.21-ea", "19.0.0-ea.6");
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(Arch.X86_64)
+                .os(Os.LINUX_GLIBC)
+                .version(version)
+                .build());
+        assertThat(path.filename()).isEqualTo("zulu19.0.21-ea-jdk19.0.0-ea.6-linux_x64");
         assertThat(path.extension()).isEqualTo(Extension.TARGZ);
     }
 


### PR DESCRIPTION
## Before this PR
If an -ea release is specified, the -ca specifier should not be.
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
If the user specifies an availability specifier (e.g. -ea, -sa, -ca) then the standard suffix of -ca is not appended.

## Possible downsides?

It's probably easier to choose a subscriber availability release.
