### PR TITLE
Use zip archives for Mac

### DIFF
--- a/changelog/@unreleased/pr-89.v2.yml
+++ b/changelog/@unreleased/pr-89.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use zip archives for Mac
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/89

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
@@ -100,12 +100,12 @@ final class AzulZuluJdkDistribution implements JdkDistribution {
         throw new UnsupportedOperationException("Case " + arch + " not implemented");
     }
 
-    private static Extension extension(Os operatingSystem) {
+    private static Extension extension(Os operatingSystem, Arch arch) {
         switch (operatingSystem) {
-            case MACOS:
             case LINUX_GLIBC:
             case LINUX_MUSL:
                 return Extension.TARGZ;
+            case MACOS:
             case WINDOWS:
                 return Extension.ZIP;
         }

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/AzulZuluJdkDistribution.java
@@ -100,7 +100,7 @@ final class AzulZuluJdkDistribution implements JdkDistribution {
         throw new UnsupportedOperationException("Case " + arch + " not implemented");
     }
 
-    private static Extension extension(Os operatingSystem, Arch arch) {
+    private static Extension extension(Os operatingSystem) {
         switch (operatingSystem) {
             case LINUX_GLIBC:
             case LINUX_MUSL:

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
@@ -67,6 +67,18 @@ class AzulZuluJdkDistributionTest {
     }
 
     @Test
+    void jdk_path_macosx() {
+        AzulZuluJdkDistribution distribution = new AzulZuluJdkDistribution();
+        String version = ZuluVersionUtils.combineZuluVersions("19.0.21", "19.0.0.6");
+        JdkPath arm = distribution.path(JdkRelease.builder()
+                .arch(Arch.AARCH64)
+                .os(Os.MACOS)
+                .version(version)
+                .build());
+        assertThat(arm.extension()).isEqualTo(Extension.ZIP);
+    }
+
+    @Test
     void jdk_path_musl_linux_x64_64() {
         AzulZuluJdkDistribution distribution = new AzulZuluJdkDistribution();
         String version = ZuluVersionUtils.combineZuluVersions("11.56.19", "11.0.15");

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/AzulZuluJdkDistributionTest.java
@@ -70,12 +70,12 @@ class AzulZuluJdkDistributionTest {
     void jdk_path_macosx() {
         AzulZuluJdkDistribution distribution = new AzulZuluJdkDistribution();
         String version = ZuluVersionUtils.combineZuluVersions("19.0.21", "19.0.0.6");
-        JdkPath arm = distribution.path(JdkRelease.builder()
+        JdkPath path = distribution.path(JdkRelease.builder()
                 .arch(Arch.AARCH64)
                 .os(Os.MACOS)
                 .version(version)
                 .build());
-        assertThat(arm.extension()).isEqualTo(Extension.ZIP);
+        assertThat(path.extension()).isEqualTo(Extension.ZIP);
     }
 
     @Test


### PR DESCRIPTION
Number of listings matching:

macosx_x64.zip: 546
macosx_x64.tar.gz: 547
macosx_aarch64.zip: 255
macosx_aarch64.tar.gz: 174

It _looks_ like the ea Mac aarch64 builds do not contain the .tar.gz version, and instead .zips are used. It seems like zips are published for all Mac releases, but only some contain .tar.gzs.