### PR TITLE
Error out if JDKs are not configured

### DIFF
--- a/changelog/@unreleased/pr-99.v2.yml
+++ b/changelog/@unreleased/pr-99.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: If a JDK for a particular Java major version is not configured, error
+    out instead of falling back to the Gradle auto-provisioning behaviour.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/99

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
@@ -170,8 +170,6 @@ class JdksPluginIntegrationSpec extends IntegrationSpec {
     }
 
     def 'throws exception if there is no JDK defined for a particular jdk major version'() {
-        // language=gradle
-
         when:
         def error = runTasksWithFailure('printJavaVersion').failure.cause.cause.message
 

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
@@ -169,6 +169,16 @@ class JdksPluginIntegrationSpec extends IntegrationSpec {
         stdout.contains amazonRootCa1Serial
     }
 
+    def 'throws exception if there is no JDK defined for a particular jdk major version'() {
+        // language=gradle
+
+        when:
+        def error = runTasksWithFailure('printJavaVersion').failure.cause.cause.message
+
+        then:
+        error.contains "Could not find a JDK with major version 11 in project ':subproject'"
+    }
+
     @Override
     ExecutionResult runTasksSuccessfully(String... tasks) {
         def result = super.runTasks(tasks)


### PR DESCRIPTION
## Before this PR
If you do not configure a JDK distribution/version for a particular java major version, the default behaviour of baseline-java-versions comes into effect, which [is to fall back to the Gradle toolchain auto-provisioning](https://github.com/palantir/gradle-baseline/blob/fd1c9981e4b9521a827c03767b080d7b999f495b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/JavaToolchains.java#L39-L44). baseline-java-versions needs to do this, because it's previous behaviour was to use the Gradle auto-provisioning. However, with this new plugin we explicitly want to avoid using the Gradle's auto-provisioning - a project accidentally not configuring JDKs is a bug.

## After this PR
==COMMIT_MSG==
If a JDK for a particular Java major version is not configured, error out instead of falling back to the Gradle auto-provisioning behaviour.
==COMMIT_MSG==

## Possible downsides?
If builds are incorrectly configured, they may start to error. IMO this is actually a good thing as we want to find these cases and stop them.

