### PR TITLE
Improvement: Support GraalVM CE distributions

### DIFF
--- a/changelog/@unreleased/pr-141.v2.yml
+++ b/changelog/@unreleased/pr-141.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support GraalVM CE distributions
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/141

--- a/gradle-jdks-distributions/src/main/java/com/palantir/gradle/jdks/JdkDistributionName.java
+++ b/gradle-jdks-distributions/src/main/java/com/palantir/gradle/jdks/JdkDistributionName.java
@@ -25,7 +25,8 @@ import java.util.stream.Collectors;
 
 public enum JdkDistributionName {
     AZUL_ZULU,
-    AMAZON_CORRETTO;
+    AMAZON_CORRETTO,
+    GRAALVM_CE;
 
     JdkDistributionName() {}
 

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GraalVmCeDistribution.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GraalVmCeDistribution.java
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.gradle.jdks.JdkPath.Extension;
+import com.palantir.gradle.jdks.JdkRelease.Arch;
+import java.util.Arrays;
+import java.util.List;
+import org.immutables.value.Value;
+
+final class GraalVmCeDistribution implements JdkDistribution {
+    @Override
+    public String defaultBaseUrl() {
+        return "https://github.com/graalvm/graalvm-ce-builds/releases/download";
+    }
+
+    @Override
+    public JdkPath path(JdkRelease jdkRelease) {
+        GraalVersionSplit splitVersion = splitVersion(jdkRelease.version());
+
+        String filename = String.format(
+                "vm-%s/graalvm-ce-java%s-%s-%s-%s",
+                splitVersion.graalVersion(),
+                splitVersion.javaVersion(),
+                os(jdkRelease.os()),
+                arch(jdkRelease.arch()),
+                splitVersion.graalVersion());
+
+        return JdkPath.builder()
+                .filename(filename)
+                .extension(extension(jdkRelease.os()))
+                .build();
+    }
+
+    private static String os(Os os) {
+        switch (os) {
+            case MACOS:
+                return "darwin";
+            case LINUX_GLIBC:
+                return "linux";
+            case WINDOWS:
+                return "windows";
+            default:
+                throw new UnsupportedOperationException("Case " + os + " not implemented");
+        }
+    }
+
+    private static String arch(Arch arch) {
+        switch (arch) {
+            case X86_64:
+                return "amd64";
+            case AARCH64:
+                return "aarch64";
+            default:
+                throw new UnsupportedOperationException("Case " + arch + " not implemented");
+        }
+    }
+
+    private static Extension extension(Os operatingSystem) {
+        switch (operatingSystem) {
+            case LINUX_GLIBC:
+            case MACOS:
+                return Extension.TARGZ;
+            case WINDOWS:
+                return Extension.ZIP;
+            default:
+                throw new UnsupportedOperationException("Unknown OS: " + operatingSystem);
+        }
+    }
+
+    @VisibleForTesting
+    static GraalVersionSplit splitVersion(String combinedVersion) {
+        int splitIndex = combinedVersion.indexOf(".");
+
+        if (splitIndex == -1) {
+            throw new IllegalArgumentException(String.format(
+                    "Expected %s to at least contain one dot separating the java version from graal version. "
+                            + "Expected Format `javaVersion.graalVersion` (e.g. 17.21.2.0 -> Java Version: 17, "
+                            + "Graal Version: 21.2.0)",
+                    combinedVersion));
+        }
+
+        List<String> split = Arrays.asList(combinedVersion.split("", -1));
+
+        if (split.size() < 2) {
+            throw new IllegalArgumentException(String.format(
+                    "Expected %s to split into at least two parts, split into %d", combinedVersion, split.size()));
+        }
+
+        return GraalVersionSplit.builder()
+                .graalVersion(combinedVersion.substring(splitIndex + 1))
+                .javaVersion(combinedVersion.substring(0, splitIndex))
+                .build();
+    }
+
+    @Value.Immutable
+    interface GraalVersionSplit {
+        String graalVersion();
+
+        String javaVersion();
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        class Builder extends ImmutableGraalVersionSplit.Builder {}
+    }
+}

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GraalVmCeDistribution.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GraalVmCeDistribution.java
@@ -19,8 +19,6 @@ package com.palantir.gradle.jdks;
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.gradle.jdks.JdkPath.Extension;
 import com.palantir.gradle.jdks.JdkRelease.Arch;
-import java.util.Arrays;
-import java.util.List;
 import org.immutables.value.Value;
 
 final class GraalVmCeDistribution implements JdkDistribution {
@@ -93,13 +91,6 @@ final class GraalVmCeDistribution implements JdkDistribution {
                             + "Expected Format `javaVersion.graalVersion` (e.g. 17.21.2.0 -> Java Version: 17, "
                             + "Graal Version: 21.2.0)",
                     combinedVersion));
-        }
-
-        List<String> split = Arrays.asList(combinedVersion.split("", -1));
-
-        if (split.size() < 2) {
-            throw new IllegalArgumentException(String.format(
-                    "Expected %s to split into at least two parts, split into %d", combinedVersion, split.size()));
         }
 
         return GraalVersionSplit.builder()

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkDistributions.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkDistributions.java
@@ -24,7 +24,9 @@ final class JdkDistributions {
             JdkDistributionName.AZUL_ZULU,
             new AzulZuluJdkDistribution(),
             JdkDistributionName.AMAZON_CORRETTO,
-            new AmazonCorrettoJdkDistribution());
+            new AmazonCorrettoJdkDistribution(),
+            JdkDistributionName.GRAALVM_CE,
+            new GraalVmCeDistribution());
 
     public JdkDistribution get(JdkDistributionName jdkDistributionName) {
         return Optional.ofNullable(JDK_DISTRIBUTIONS.get(jdkDistributionName))

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -38,6 +38,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.stream.Stream;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
+import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Provider;
 import org.gradle.process.ExecResult;
@@ -116,6 +117,7 @@ public final class JdkManager {
             project.copy(copy -> {
                 copy.from(unpackTree(project, jdkPath.extension(), jdkArchive));
                 copy.into(temporaryJdkPath);
+                copy.setDuplicatesStrategy(DuplicatesStrategy.WARN);
             });
 
             Path javaHome = findJavaHome(temporaryJdkPath);

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GraalVmCeDistributionTest.java
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GraalVmCeDistributionTest.java
@@ -1,0 +1,70 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.gradle.jdks.GraalVmCeDistribution.GraalVersionSplit;
+import com.palantir.gradle.jdks.JdkPath.Extension;
+import com.palantir.gradle.jdks.JdkRelease.Arch;
+import org.junit.jupiter.api.Test;
+
+class GraalVmCeDistributionTest {
+
+    @Test
+    void graalvm_ce_version_splits_version() {
+        GraalVersionSplit versionSplit = GraalVmCeDistribution.splitVersion("17.23.2.0");
+        assertThat(versionSplit.javaVersion()).isEqualTo("17");
+        assertThat(versionSplit.graalVersion()).isEqualTo("23.2.0");
+    }
+
+    @Test
+    void jdk_path_linux_x86_64() {
+        GraalVmCeDistribution distribution = new GraalVmCeDistribution();
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(Arch.X86_64)
+                .os(Os.LINUX_GLIBC)
+                .version("17.22.3.0")
+                .build());
+        assertThat(path.filename()).isEqualTo("vm-22.3.0/graalvm-ce-java17-linux-amd64-22.3.0");
+        assertThat(path.extension()).isEqualTo(Extension.TARGZ);
+    }
+
+    @Test
+    void jdk_path_macosx() {
+        GraalVmCeDistribution distribution = new GraalVmCeDistribution();
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(Arch.AARCH64)
+                .os(Os.MACOS)
+                .version("19.22.3.0")
+                .build());
+        assertThat(path.filename()).isEqualTo("vm-22.3.0/graalvm-ce-java19-darwin-aarch64-22.3.0");
+        assertThat(path.extension()).isEqualTo(Extension.TARGZ);
+    }
+
+    @Test
+    void jdk_path_windows_x86_64() {
+        GraalVmCeDistribution distribution = new GraalVmCeDistribution();
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(Arch.X86_64)
+                .os(Os.WINDOWS)
+                .version("11.20.3.6")
+                .build());
+        assertThat(path.filename()).isEqualTo("vm-20.3.6/graalvm-ce-java11-windows-amd64-20.3.6");
+        assertThat(path.extension()).isEqualTo(Extension.ZIP);
+    }
+}

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/JdksPluginIntegrationSpec.groovy
@@ -98,6 +98,24 @@ class JdksPluginIntegrationSpec extends IntegrationSpec {
         stdout.contains 'version: 11.0.16.1, vendor: Amazon.com Inc.'
     }
 
+    def 'can download + run on GraalVM Community Edition JDK'() {
+        // language=gradle
+        buildFile << '''
+            jdks {                
+                jdk(11) {
+                    distribution = 'graalvm-ce'
+                    jdkVersion = '11.22.3.0'    
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        def stdout = runTasksSuccessfully('printJavaVersion').standardOutput
+
+        then:
+        stdout.contains 'version: 11.0.17, vendor: GraalVM Community'
+    }
+
     def 'can add ca certs to a JDK'() {
         def amazonRootCa1Serial = '143266978916655856878034712317230054538369994'
 


### PR DESCRIPTION
## Before this PR
One could only use Azul or Amazon's JDKs. To use the GraalVM CE distribution, I had to disable the java versions tooling so that I can override `JAVA_HOME` that Gradle was using.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support GraalVM CE distributions
==COMMIT_MSG==

## Possible downsides?
I'm unsure if musl/alpine linux is actually supported for GraalVM so I didn't implement that case. There seems to be no mention explicitly of it in https://www.graalvm.org/latest/docs/introduction/#available-distributions

