### PR TITLE
Produce Palantir CA Plugin

### DIFF
--- a/changelog/@unreleased/pr-161.v2.yml
+++ b/changelog/@unreleased/pr-161.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Produce `com.palantir.jdks.palantir-ca` plugin for use by other Gradle
+    plugins to enable using open source projects from within the corporate VPN.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/161

--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -35,6 +35,12 @@ gradlePlugin {
             description = 'Auto-provisions specific versions of JDKs'
             implementationClass = 'com.palantir.gradle.jdks.JdksPlugin'
         }
+        palantirCa {
+            id = 'com.palantir.jdks.palantir-ca'
+            displayName = 'Palantir CA for gradle-jdks'
+            description = 'Includes the Palantir CA from the system truststore'
+            implementationClass = 'com.palantir.gradle.jdks.PalantirCaPlugin'
+        }
     }
 }
 

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/PalantirCaExtension.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/PalantirCaExtension.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.provider.Property;
+
+public abstract class PalantirCaExtension {
+    public abstract Property<LogLevel> getLogLevel();
+
+    public PalantirCaExtension() {
+        getLogLevel().set(LogLevel.INFO);
+    }
+}

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/PalantirCaPluginIntegrationSpec.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/PalantirCaPluginIntegrationSpec.groovy
@@ -25,7 +25,7 @@ class PalantirCaPluginIntegrationSpec extends IntegrationSpec {
         // language=gradle
         buildFile << '''
             // Can't do strict as open source CI does not have the Palantir CA
-            com.palantir.gradle.jdks.PalantirCa.applyToRootProject(rootProject, false)
+            apply plugin: 'com.palantir.jdks.palantir-ca'
     
             jdks {
                 jdk(11) {


### PR DESCRIPTION
## Before this PR
We had a class that enabled other plugins to call it and it would include the Palantir corporate CA cert into JDKs, if it exists in the system truststore. This enables people to run tests in open source projects that hit public webservers from within the corporate VPN.

However, none of the other plugins (`gradle-jdks-latest` or `gradle-jdks-internal`) actually enable this.

## After this PR
We now produce a plugin rather than a class so multiple other plugins can apply it without worrying if it's already been applied.

==COMMIT_MSG==
Produce `com.palantir.jdks.palantir-ca` plugin for use by other Gradle plugins to enable using open source projects from within the corporate VPN.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

