### PR TITLE
Don't fail when linux ca-bundle file does exist for Palantir CAs. Also support centos

### DIFF
--- a/changelog/@unreleased/pr-163.v2.yml
+++ b/changelog/@unreleased/pr-163.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    * Support reading Palantir CA from the truststores of Redhat based systems
+    * Do not fail if the system truststore cannot be found on linux
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/163

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/PalantirCaPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/PalantirCaPlugin.java
@@ -80,7 +80,7 @@ public final class PalantirCaPlugin implements Plugin<Project> {
                 return Optional.of(macosSystemCertificates(rootProject));
             case LINUX_GLIBC:
             case LINUX_MUSL:
-                return Optional.of(linuxSystemCertificates());
+                return linuxSystemCertificates();
             default:
                 log(
                         "Not attempting to read Palantir CA from system truststore "
@@ -117,11 +117,16 @@ public final class PalantirCaPlugin implements Plugin<Project> {
         return output.toByteArray();
     }
 
-    private static byte[] linuxSystemCertificates() {
+    private Optional<byte[]> linuxSystemCertificates() {
         Path caCertificatePath = Paths.get("/etc/ssl/certs/ca-certificates.crt");
 
+        if (Files.notExists(caCertificatePath)) {
+            log("Could not find system truststore at {} in order to load Palantir CA cert", caCertificatePath);
+            return Optional.empty();
+        }
+
         try {
-            return Files.readAllBytes(caCertificatePath);
+            return Optional.of(Files.readAllBytes(caCertificatePath));
         } catch (IOException e) {
             throw new RuntimeException("Failed to read CA certs from " + caCertificatePath, e);
         }


### PR DESCRIPTION
## Before this PR
Internally, a service has a build that uses a redhat based linux rather than ubuntu. It does not have `/etc/ssl/certs/ca-certificates.crt`. Instead it has:

```
$ ls -l /etc/ssl/certs/
total 16
lrwxrwxrwx 1 root root   49 Sep 30  2021 ca-bundle.crt -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
lrwxrwxrwx 1 root root   55 Sep 30  2021 ca-bundle.trust.crt -> /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
```

It fails with an error that:

```
Caused by: java.nio.file.NoSuchFileException: /etc/ssl/certs/ca-certificates.crt
	at com.palantir.gradle.jdks.PalantirCaPlugin.linuxSystemCertificates(PalantirCaPlugin.java:124)
```

## After this PR
==COMMIT_MSG==
* Support reading Palantir CA from the truststores of Redhat based systems
* Do not fail if the system truststore cannot be found on linux
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

