### PR TITLE
Look for `javac` instead of `java`

### DIFF
--- a/changelog/@unreleased/pr-184.yml
+++ b/changelog/@unreleased/pr-184.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use bin/javac to find JAVA_HOME instead of bin/java to avoid accidentally installing a JRE instead of a JDK.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/184

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -194,7 +194,7 @@ public final class JdkManager {
             return files.filter(file -> Files.isRegularFile(file)
                             // macos JDKs have a `bin/java` symlink to `Contents/Home/bin/java`
                             && !Files.isSymbolicLink(file)
-                            && file.endsWith(Paths.get("bin", SystemTools.java())))
+                            && file.endsWith(Paths.get("bin", SystemTools.javac())))
                     .findFirst()
                     // JAVA_HOME/bin/java
                     .orElseThrow(() -> new RuntimeException("Failed to find java home in " + temporaryJdkPath))

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/SystemTools.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/SystemTools.java
@@ -26,6 +26,13 @@ final class SystemTools {
         return "java";
     }
 
+    static String javac() {
+        if (Os.current() == Os.WINDOWS) {
+            return "javac.exe";
+        }
+        return "javac";
+    }
+
     static String keytool() {
         if (Os.current() == Os.WINDOWS) {
             return "keytool.exe";


### PR DESCRIPTION
There are some situations where using `bin/java` as a heuristic to find JAVA_HOME within a JDK package can result in mistakenly finding a JRE root instead. Looking for `bin/javac` fixes this since JREs do not have `javac`.

This should fix https://github.com/palantir/gradle-jdks/issues/97

## Before this PR

The `findJavaHome` method could mistakenly find a JRE inside of the JDK packages instead of the JDK resulting in an unusable JAVA_HOME. This main impacted some older JDKs.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use `bin/javac` to find JAVA_HOME instead of `bin/java` to avoid accidentally installing a JRE instead of a JDK.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

