### PR TITLE
Try to avoid `This property is in an unexpected state` errors 

### DIFF
--- a/changelog/@unreleased/pr-294.v2.yml
+++ b/changelog/@unreleased/pr-294.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Try to avoid `This property is in an unexpected state` errors
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/294

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksJavaInstallationMetadata.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksJavaInstallationMetadata.java
@@ -25,9 +25,9 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion;
 final class GradleJdksJavaInstallationMetadata {
     public static JavaInstallationMetadata create(
             JavaLanguageVersion javaLanguageVersion,
-            Provider<String> javaRuntimeVersion,
-            Provider<String> jvmVersion,
-            Provider<String> vendor,
+            String javaRuntimeVersion,
+            String jvmVersion,
+            String vendor,
             Provider<Directory> installationPath) {
         return (JavaInstallationMetadata) Proxy.newProxyInstance(
                 GradleJdksJavaInstallationMetadata.class.getClassLoader(),
@@ -42,11 +42,11 @@ final class GradleJdksJavaInstallationMetadata {
                         case "getLanguageVersion":
                             return javaLanguageVersion;
                         case "getJavaRuntimeVersion":
-                            return javaRuntimeVersion.get();
+                            return javaRuntimeVersion;
                         case "getJvmVersion":
-                            return jvmVersion.get();
+                            return jvmVersion;
                         case "getVendor":
-                            return vendor.get();
+                            return vendor;
                         case "getInstallationPath":
                             return installationPath.get();
                         case "isCurrentJvm":

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkExtension.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkExtension.java
@@ -36,9 +36,6 @@ public abstract class JdkExtension {
     protected abstract ObjectFactory getObjectFactory();
 
     public JdkExtension() {
-        getJdkVersion().finalizeValueOnRead();
-        getDistributionName().finalizeValueOnRead();
-
         for (Os os : Os.values()) {
             JdkOsExtension jdkOsExtension = getObjectFactory().newInstance(JdkOsExtension.class);
             jdkOsExtension.getJdkVersion().set(getJdkVersion());

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkOsArchExtension.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkOsArchExtension.java
@@ -22,10 +22,6 @@ import org.gradle.api.provider.Property;
 public abstract class JdkOsArchExtension {
     public abstract Property<String> getJdkVersion();
 
-    public JdkOsArchExtension() {
-        getJdkVersion().finalizeValueOnRead();
-    }
-
     public final void fromJson(JdkOsArchInfoJson archInfo) {
         getJdkVersion().set(archInfo.version());
     }

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkOsExtension.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkOsExtension.java
@@ -33,8 +33,6 @@ public abstract class JdkOsExtension {
     private final Map<Arch, JdkOsArchExtension> jdkOsArchExtensions = new HashMap<>();
 
     public JdkOsExtension() {
-        getJdkVersion().finalizeValueOnRead();
-
         for (Arch arch : Arch.values()) {
             JdkOsArchExtension jdkOsArchExtension = getObjectFactory().newInstance(JdkOsArchExtension.class);
             jdkOsArchExtension.getJdkVersion().set(getJdkVersion());

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdksPlugin.java
@@ -93,18 +93,22 @@ public final class JdksPlugin implements Plugin<Project> {
         Os currentOs = CurrentOs.get();
         Arch currentArch = CurrentArch.get();
 
-        Provider<String> version =
-                jdkExtension.jdkFor(currentOs).jdkFor(currentArch).getJdkVersion();
+        String version = jdkExtension
+                .jdkFor(currentOs)
+                .jdkFor(currentArch)
+                .getJdkVersion()
+                .get();
 
-        Provider<JdkDistributionName> jdkDistributionName = jdkExtension.getDistributionName();
+        JdkDistributionName jdkDistributionName =
+                jdkExtension.getDistributionName().get();
 
         Provider<Directory> installationPath = project.getLayout().dir(project.provider(() -> jdkManager
                 .jdk(
                         project,
                         JdkSpec.builder()
-                                .distributionName(jdkDistributionName.get())
+                                .distributionName(jdkDistributionName)
                                 .release(JdkRelease.builder()
-                                        .version(version.get())
+                                        .version(version)
                                         .os(currentOs)
                                         .arch(currentArch)
                                         .build())
@@ -113,10 +117,6 @@ public final class JdksPlugin implements Plugin<Project> {
                 .toFile()));
 
         return GradleJdksJavaInstallationMetadata.create(
-                javaLanguageVersion,
-                version,
-                version,
-                jdkDistributionName.map(JdkDistributionName::uiName),
-                installationPath);
+                javaLanguageVersion, version, version, jdkDistributionName.uiName(), installationPath);
     }
 }


### PR DESCRIPTION
## Before this PR
Internally, we are seeing a lot of errors with #286 of this form:

```
Execution failed for task ':blah:blah:javadoc'.
> Failed to calculate the value of property 'distributionName'.
   > This property is in an unexpected state.
```

I think this is similar to what we encountered in #51. baseline-java-versions/Gradle gets JDKs in parallel on different threads. Gradle really isn't set up to handle this multi-threading, especially when it comes to finalizing property values. Gradle even has [this comment](https://github.com/gradle/gradle/blob/28aca86a7180baa17117e0e5ba01d8ea9feca598/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java#L528-L529):

> // TODO - it is currently possible for multiple threads to finalize a property instance concurrently (https://github.com/gradle/gradle/issues/12811)

I think when making stuff `finalizeValueOnRead` we now encounter this bug.

## After this PR
==COMMIT_MSG==
Try to avoid `This property is in an unexpected state` errors 
==COMMIT_MSG==

We do this by not doing `finalizeValueOnRead`.

I also removed some of the "extra" laziness I introduced in the previous PR. This extra laziness gave more places where this property could be finalised on different threads, and I don't think we need the extra laziness (or at least did fine without it before).

## Possible downsides?
I can't repro this locally. It seems to happen on <1% of builds according to the build scan server. So no tests, this is purely an educated guess whether it will fix this.
