### PR TITLE
Bump intellij dependency

### DIFF
--- a/changelog/@unreleased/pr-376.v2.yml
+++ b/changelog/@unreleased/pr-376.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Bump intellij dependency
   links:
   - https://github.com/palantir/gradle-jdks/pull/376

--- a/changelog/@unreleased/pr-376.v2.yml
+++ b/changelog/@unreleased/pr-376.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump intellij dependency
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/376

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -15,7 +15,7 @@ def buildPlugin = tasks.named("buildPlugin")
 patchPluginXml {
     pluginDescription = "Configures the Gradle JDKs for the Toolchains used for a project and for the Gradle Daemon."
     version = project.version
-    sinceBuild = '232' // TODO: test against this version of IntelliJ to ensure no regressions
+    sinceBuild = '241' // TODO: test against this version of IntelliJ to ensure no regressions
     untilBuild = ''
 }
 

--- a/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksExternalSystemTaskNotificationListener.java
+++ b/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksExternalSystemTaskNotificationListener.java
@@ -35,9 +35,6 @@ public final class GradleJdksExternalSystemTaskNotificationListener implements E
     }
 
     @Override
-    public void onStart(@NotNull ExternalSystemTaskId _id) {}
-
-    @Override
     public void onEnvironmentPrepared(@NotNull ExternalSystemTaskId _id) {}
 
     @Override

--- a/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksExternalSystemTaskNotificationListener.java
+++ b/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksExternalSystemTaskNotificationListener.java
@@ -35,9 +35,6 @@ public final class GradleJdksExternalSystemTaskNotificationListener implements E
     }
 
     @Override
-    public void onEnvironmentPrepared(@NotNull ExternalSystemTaskId _id) {}
-
-    @Override
     public void onStatusChange(@NotNull ExternalSystemTaskNotificationEvent _event) {}
 
     @Override


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
![Screenshot 2024-07-03 at 16 10 28](https://github.com/palantir/gradle-jdks/assets/25724655/6c7d4029-d541-4bd5-bb3a-d899260096d3)

onStart method marked for removal.

## After this PR
Removing the deprecated `onStart` override & Bumping the intellij dependency
==COMMIT_MSG==
Bump intellij dependency
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

