### PR TITLE
[Intellij] Focus on `Gradle Jdk` Tool Window while the setup is running

### DIFF
--- a/changelog/@unreleased/pr-379.v2.yml
+++ b/changelog/@unreleased/pr-379.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[Intellij] Focus on `Gradle Jdk` Tool Window while the setup is running'
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/379

--- a/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksExternalSystemTaskNotificationListener.java
+++ b/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksExternalSystemTaskNotificationListener.java
@@ -30,7 +30,7 @@ public final class GradleJdksExternalSystemTaskNotificationListener implements E
         if (id.getProjectSystemId().equals(GradleConstants.SYSTEM_ID)
                 && (id.getType() == ExternalSystemTaskType.RESOLVE_PROJECT
                         || id.getType() == ExternalSystemTaskType.EXECUTE_TASK)) {
-            id.findProject().getService(GradleJdksProjectService.class).maybeSetupGradleJdks();
+            id.findProject().getService(GradleJdksProjectService.class).maybeSetupGradleJdks(id.getType());
         }
     }
 

--- a/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksToolWindowService.java
+++ b/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksToolWindowService.java
@@ -16,7 +16,71 @@
 
 package com.palantir.gradle.jdks;
 
+import com.google.common.base.Suppliers;
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowAnchor;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import java.util.function.Supplier;
 
 @Service(Service.Level.PROJECT)
-public final class GradleJdksToolWindowService {}
+public final class GradleJdksToolWindowService {
+
+    static final String TOOL_WINDOW_NAME = "Gradle JDK Setup";
+
+    private final Supplier<ConsoleView> consoleView = Suppliers.memoize(this::initConsoleView);
+    private final Project project;
+
+    public GradleJdksToolWindowService(Project project) {
+        this.project = project;
+    }
+
+    private ConsoleView initConsoleView() {
+        ConsoleView newConsoleView =
+                TextConsoleBuilderFactory.getInstance().createBuilder(project).getConsole();
+
+        ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
+        toolWindowManager.invokeLater(() -> {
+            ToolWindow toolWindow = toolWindowManager.getToolWindow(TOOL_WINDOW_NAME);
+            if (toolWindow == null) {
+                toolWindow = toolWindowManager.registerToolWindow(TOOL_WINDOW_NAME, true, ToolWindowAnchor.BOTTOM);
+            }
+            ContentFactory contentFactory = ContentFactory.getInstance();
+            Content content = contentFactory.createContent(newConsoleView.getComponent(), "", false);
+            toolWindow.getContentManager().addContent(content);
+            toolWindow.setAvailable(true);
+            toolWindow.activate(null, true, false);
+        });
+
+        return newConsoleView;
+    }
+
+    public void focusOnWindow(String toolWindowId) {
+        ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
+        toolWindowManager.invokeLater(() -> {
+            ToolWindow toolWindow = toolWindowManager.getToolWindow(toolWindowId);
+            if (toolWindow != null) {
+                toolWindow.activate(null, true, false);
+            }
+        });
+    }
+
+    public void hideWindow(String toolWindowId) {
+        ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
+        toolWindowManager.invokeLater(() -> {
+            ToolWindow toolWindow = toolWindowManager.getToolWindow(toolWindowId);
+            if (toolWindow != null) {
+                toolWindow.hide(null);
+            }
+        });
+    }
+
+    public ConsoleView getConsoleView() {
+        return consoleView.get();
+    }
+}

--- a/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksToolWindowService.java
+++ b/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksToolWindowService.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+import com.intellij.openapi.components.Service;
+
+@Service(Service.Level.PROJECT)
+public final class GradleJdksToolWindowService {}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We would always focus on the "Gradle JDK setup" tool window. In case the user triggered a task eg. running a test/a gradle task, the focus stays on the `Gradle JDK setup` Tool window, instead of the Task the user triggered.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
- when `Gradle JDK Setup` is running, we are focusing on the corresponding tool window
- if the setup succeeded, then we will focus on the "Build" or "Run" tool Windows, depending on the type of task that triggered the JDK setup.

==COMMIT_MSG==
[Intellij] Focus on `Gradle Jdk` Tool Window while the setup is running
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

