### PR TITLE
[Gradle JDK] Fix when `palantir-gradle-jdks` is not installed and jdks are missing

### DIFF
--- a/changelog/@unreleased/pr-382.v2.yml
+++ b/changelog/@unreleased/pr-382.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '[Gradle JDK] Fix when `palantir-gradle-jdks` is not installed and
+    jdks are missing'
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/382

--- a/gradle-jdks-settings/build.gradle
+++ b/gradle-jdks-settings/build.gradle
@@ -50,8 +50,10 @@ publishing.publications {
     }
 }
 
-tasks.test {
-    environment(Map.of("HOME", "/tmp"))
+// Changing the location where the gradle jdks are installed such that the settings plugin can run the
+// gradle-jdks-setup.sh configuration script to install the missing jdks.
+tasks.withType(Test) {
+    environment("HOME", "/tmp")
     systemProperty 'user.home', '/tmp'
 }
 

--- a/gradle-jdks-settings/build.gradle
+++ b/gradle-jdks-settings/build.gradle
@@ -9,6 +9,11 @@ dependencies {
     // settings classLoader and the build classLoaders.
     shadeTransitively project(':gradle-jdks-setup-common')
     shadeTransitively project(':gradle-jdks-enablement')
+
+    testImplementation gradleTestKit()
+    testImplementation 'com.netflix.nebula:nebula-test'
+    testImplementation 'org.apache.commons:commons-compress'
+    testImplementation project(':gradle-jdks-test-common')
 }
 
 gradlePlugin {
@@ -44,3 +49,9 @@ publishing.publications {
         }
     }
 }
+
+tasks.test {
+    environment(Map.of("HOME", "/tmp"))
+    systemProperty 'user.home', '/tmp'
+}
+

--- a/gradle-jdks-settings/build.gradle
+++ b/gradle-jdks-settings/build.gradle
@@ -53,7 +53,7 @@ publishing.publications {
 // Changing the location where the gradle jdks are installed such that the settings plugin can run the
 // gradle-jdks-setup.sh configuration script to install the missing jdks.
 tasks.withType(Test) {
-    environment("HOME", "/tmp")
-    systemProperty 'user.home', '/tmp'
+    environment("HOME", "/tmp/gradleJdksSettingsTest")
+    systemProperty 'user.home', '/tmp/gradleJdksSettingsTest'
 }
 

--- a/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
+++ b/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
@@ -175,20 +175,20 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
         try (Stream<Path> stream = Files.list(gradleJdksLocalDirectory).filter(Files::isDirectory)) {
             return stream.map(path ->
                             path.resolve(os.toString()).resolve(arch.toString()).resolve("local-path"))
-                    .map(path -> resolvePath(path, installationDirectory))
+                    .map(path -> resolveJdkPath(path, installationDirectory))
                     .collect(Collectors.toList());
         } catch (IOException e) {
-            throw new RuntimeException("Unable to list the local installation paths", e);
+            throw new RuntimeException("Unable to list the local JDK installation paths", e);
         }
     }
 
-    private static Path resolvePath(Path gradleJdkConfigurationPath, Path installationDirectory) {
+    private static Path resolveJdkPath(Path gradleJdkConfigurationPath, Path installationDirectory) {
         try {
             String localFilename = Files.readString(gradleJdkConfigurationPath).trim();
             return installationDirectory.resolve(localFilename);
         } catch (IOException e) {
             throw new RuntimeException(
-                    String.format("Failed to get the toolchain configured at path=%s", gradleJdkConfigurationPath), e);
+                    String.format("Failed to read gradle jdk configuration file %s", gradleJdkConfigurationPath), e);
         }
     }
 

--- a/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
+++ b/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
@@ -159,7 +159,8 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
                     "Gradle JDK setup is enabled (palantir.jdk.setup.enabled is true) but some jdks were not"
                             + " installed: {}. If running from Intellij, please make sure the"
                             + " `palantir-gradle-jdks` Intellij plugin is installed"
-                            + " https://plugins.jetbrains.com/plugin/24776-palantir-gradle-jdks/versions.",
+                            + " https://plugins.jetbrains.com/plugin/24776-palantir-gradle-jdks/versions."
+                            + " To unblock the workflow, the jdks will be manually installed now ...",
                     missingJdkPaths);
             runGradleJdkSetup(rootProjectDir);
         }

--- a/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
+++ b/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
@@ -128,11 +128,6 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
             // see: https://github.com/gradle/gradle/blob/4bd1b3d3fc3f31db5a26eecb416a165b8cc36082/subprojects/core-api/
             // src/main/java/org/gradle/api/internal/properties/GradleProperties.java#L28
             if (method.getName().equals("find") && args.length == 1) {
-                logger.info(
-                        "Running find method for args {} {} {}",
-                        args,
-                        Thread.currentThread().getName(),
-                        ProcessHandle.current().pid());
                 List<Path> installedLocalToolchains = getOrInstallJdkPaths(rootProjectDir, gradleJdksLocalDirectory);
                 String onlyArg = (String) args[0];
                 if (onlyArg.equals("org.gradle.java.installations.auto-detect")

--- a/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
+++ b/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
@@ -212,14 +212,14 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
     }
 
     private static Void writeStdOutput(InputStream inputStream) {
-        return CommandRunner.write(inputStream, line -> {
+        return CommandRunner.processStream(inputStream, line -> {
             logger.lifecycle(line);
             return null;
         });
     }
 
     private static Void writeStdErr(InputStream inputStream) {
-        return CommandRunner.write(inputStream, line -> {
+        return CommandRunner.processStream(inputStream, line -> {
             logger.error(line);
             return null;
         });

--- a/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
+++ b/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
@@ -20,6 +20,7 @@ package com.palantir.gradle.jdks.settings;
 
 import com.palantir.gradle.jdks.enablement.GradleJdksEnablement;
 import com.palantir.gradle.jdks.setup.common.Arch;
+import com.palantir.gradle.jdks.setup.common.CommandRunner;
 import com.palantir.gradle.jdks.setup.common.CurrentArch;
 import com.palantir.gradle.jdks.setup.common.CurrentOs;
 import com.palantir.gradle.jdks.setup.common.Os;
@@ -67,6 +68,7 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
                             + " Please upgrade to a higher Gradle version in order to use the JDK setup.",
                     GradleJdksEnablement.MINIMUM_SUPPORTED_GRADLE_VERSION));
         }
+        Path rootProjectDir = settings.getRootDir().toPath();
         Path gradleJdksLocalDirectory = settings.getRootDir().toPath().resolve("gradle/jdks");
         // Not failing here because the plugin might be applied before the `./gradlew setupJdks` is run, hence not
         // having the expected directory structure.
@@ -75,6 +77,7 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
                     + " ./gradlew setupJdks to set up the JDKs.");
             return;
         }
+
         ProviderFactory providerFactory =
                 ((DefaultSettings) settings).getServices().get(ProviderFactory.class);
         if (!(providerFactory instanceof DefaultProviderFactory)) {
@@ -97,7 +100,8 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
             GradleProperties ourGradleProperties = (GradleProperties) Proxy.newProxyInstance(
                     GradleProperties.class.getClassLoader(),
                     new Class[] {GradleProperties.class},
-                    new GradlePropertiesInvocationHandler(gradleJdksLocalDirectory, originalGradleProperties));
+                    new GradlePropertiesInvocationHandler(
+                            rootProjectDir, gradleJdksLocalDirectory, originalGradleProperties));
             field.set(defaultValueSourceProviderFactory, ourGradleProperties);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException("Failed to update the Gradle JDK properties using reflection", e);
@@ -107,25 +111,27 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
     private static class GradlePropertiesInvocationHandler implements InvocationHandler {
         private final GradleProperties originalGradleProperties;
         private final Path gradleJdksLocalDirectory;
+        private final Path rootProjectDir;
 
-        GradlePropertiesInvocationHandler(Path gradleJdksLocalDirectory, GradleProperties originalGradleProperties) {
+        GradlePropertiesInvocationHandler(
+                Path rootProjectDir, Path gradleJdksLocalDirectory, GradleProperties originalGradleProperties) {
+            this.rootProjectDir = rootProjectDir;
             this.gradleJdksLocalDirectory = gradleJdksLocalDirectory;
             this.originalGradleProperties = originalGradleProperties;
         }
 
         @Override
         public Object invoke(Object _proxy, Method method, Object[] args) throws Throwable {
-            List<Path> localToolchains = getInstalledToolchains(gradleJdksLocalDirectory);
-            if (localToolchains.isEmpty()) {
-                logger.warn(
-                        "Gradle JDK setup is enabled (palantir.jdk.setup.enabled is true) but no jdks could be found."
-                                + " If running from Intellij, please make sure the `palantir-gradle-jdks` Intellij"
-                                + " plugin is installed"
-                                + " https://plugins.jetbrains.com/plugin/24776-palantir-gradle-jdks/versions.");
-                return GradleProperties.class
-                        .getDeclaredMethod(method.getName(), method.getParameterTypes())
-                        .invoke(originalGradleProperties, args);
+            List<Optional<Path>> localToolchains = getInstalledToolchains(gradleJdksLocalDirectory);
+            if (localToolchains.stream().anyMatch(Optional::isEmpty)) {
+                logger.error("Gradle JDK setup is enabled (palantir.jdk.setup.enabled is true) but some jdks were not"
+                        + " installed. If running from Intellij, please make sure the `palantir-gradle-jdks`"
+                        + " Intellij plugin is installed"
+                        + " https://plugins.jetbrains.com/plugin/24776-palantir-gradle-jdks/versions.");
+                runGradleJdkSetup(rootProjectDir);
             }
+            List<Path> installedLocalToolchains =
+                    localToolchains.stream().flatMap(Optional::stream).collect(Collectors.toList());
             // see: https://github.com/gradle/gradle/blob/4bd1b3d3fc3f31db5a26eecb416a165b8cc36082/subprojects/core-api/
             // src/main/java/org/gradle/api/internal/properties/GradleProperties.java#L28
             if (method.getName().equals("find") && args.length == 1) {
@@ -135,7 +141,7 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
                     return "false";
                 }
                 if (onlyArg.equals("org.gradle.java.installations.paths")) {
-                    return localToolchains.stream()
+                    return installedLocalToolchains.stream()
                             .map(Path::toAbsolutePath)
                             .map(Path::toString)
                             .collect(Collectors.joining(","));
@@ -149,43 +155,34 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
                 throw e.getCause();
             }
         }
+    }
 
-        private static List<Path> getInstalledToolchains(Path gradleJdksLocalDirectory) {
-            Path installationDirectory = getToolchainInstallationDir();
-            Os os = CurrentOs.get();
-            Arch arch = CurrentArch.get();
-            try (Stream<Path> stream = Files.list(gradleJdksLocalDirectory).filter(Files::isDirectory)) {
-                return stream.map(path -> path.resolve(os.toString())
-                                .resolve(arch.toString())
-                                .resolve("local-path"))
-                        .map(path -> maybeGetToolchain(path, installationDirectory))
-                        .flatMap(Optional::stream)
-                        .collect(Collectors.toList());
-            } catch (IOException e) {
-                throw new RuntimeException("Unable to list the local installation paths", e);
-            }
+    private static List<Optional<Path>> getInstalledToolchains(Path gradleJdksLocalDirectory) {
+        Path installationDirectory = getToolchainInstallationDir();
+        Os os = CurrentOs.get();
+        Arch arch = CurrentArch.get();
+        try (Stream<Path> stream = Files.list(gradleJdksLocalDirectory).filter(Files::isDirectory)) {
+            return stream.map(path ->
+                            path.resolve(os.toString()).resolve(arch.toString()).resolve("local-path"))
+                    .map(path -> maybeGetToolchain(path, installationDirectory))
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to list the local installation paths", e);
         }
+    }
 
-        private static Optional<Path> maybeGetToolchain(Path gradleJdkConfigurationPath, Path installationDirectory) {
-            try {
-                String localFilename =
-                        Files.readString(gradleJdkConfigurationPath).trim();
-                Path installationPath = installationDirectory.resolve(localFilename);
-                if (!Files.exists(installationPath)) {
-                    logger.warn(
-                            "Gradle JDKS setup is enabled but the configured jdk {} could not be found. If running"
-                                    + " from Intellij, please make sure the `palantir-gradle-jdks` Intellij plugin is"
-                                    + " installed "
-                                    + "https://plugins.jetbrains.com/plugin/24776-palantir-gradle-jdks/versions",
-                            installationPath);
-                    return Optional.empty();
-                }
-                return Optional.of(installationPath);
-            } catch (IOException e) {
-                throw new RuntimeException(
-                        String.format("Failed to get the toolchain configured at path=%s", gradleJdkConfigurationPath),
-                        e);
+    private static Optional<Path> maybeGetToolchain(Path gradleJdkConfigurationPath, Path installationDirectory) {
+        try {
+            String localFilename = Files.readString(gradleJdkConfigurationPath).trim();
+            Path installationPath = installationDirectory.resolve(localFilename);
+            if (!Files.exists(installationPath)) {
+                logger.warn("Gradle JDKS setup is enabled but the jdk {} was not installed.", installationPath);
+                return Optional.empty();
             }
+            return Optional.of(installationPath);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    String.format("Failed to get the toolchain configured at path=%s", gradleJdkConfigurationPath), e);
         }
     }
 
@@ -199,5 +196,9 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
         return GradleVersion.current()
                         .compareTo(GradleVersion.version(GradleJdksEnablement.MINIMUM_SUPPORTED_GRADLE_VERSION))
                 >= 0;
+    }
+
+    private static void runGradleJdkSetup(Path rootProjectDir) {
+        CommandRunner.run(List.of("./gradle/gradle-jdks-setup.sh"), Optional.of(rootProjectDir.toFile()));
     }
 }

--- a/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
+++ b/gradle-jdks-settings/src/main/java/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPlugin.java
@@ -212,18 +212,12 @@ public final class ToolchainJdksSettingsPlugin implements Plugin<Settings> {
                 ToolchainJdksSettingsPlugin::writeStdErr);
     }
 
-    private static Void writeStdOutput(InputStream inputStream) {
-        return CommandRunner.processStream(inputStream, line -> {
-            logger.lifecycle(line);
-            return null;
-        });
+    private static void writeStdOutput(InputStream inputStream) {
+        CommandRunner.processStream(inputStream, logger::lifecycle);
     }
 
-    private static Void writeStdErr(InputStream inputStream) {
-        return CommandRunner.processStream(inputStream, line -> {
-            logger.error(line);
-            return null;
-        });
+    private static void writeStdErr(InputStream inputStream) {
+        CommandRunner.processStream(inputStream, logger::error);
     }
 
     private static void createDirectories(Path path) {

--- a/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
+++ b/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks.settings
+
+import com.palantir.gradle.jdks.GradleJdkTestUtils
+import com.palantir.gradle.jdks.setup.common.CurrentArch
+import com.palantir.gradle.jdks.setup.common.CurrentOs
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
+
+    def '#gradleVersionNumber: non-existing jdks are installed by the settings plugin'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
+        GradleJdkTestUtils.applyJdksPlugins(settingsFile, buildFile)
+
+        // language=groovy
+        buildFile << """
+            jdks {
+               jdk(17) {
+                  distribution = JDK_17_DISTRO
+                  jdkVersion = JDK_17_VERSION
+               }
+               
+                daemonTarget = '17'
+            }
+        """.replace("JDK_17_DISTRO", GradleJdkTestUtils.quoted(GradleJdkTestUtils.JDK_17.getLeft()))
+                .replace("JDK_17_VERSION", GradleJdkTestUtils.quoted(GradleJdkTestUtils.JDK_17.getRight()))
+                .stripIndent(true)
+
+        when:
+        file('gradle.properties') << 'palantir.jdk.setup.enabled=true'
+        runTasksSuccessfully("generateGradleJdkConfigs")
+
+        then: 'only gradle configuration files are generated, no jdks are installed'
+        String os = CurrentOs.get().uiName()
+        String arch = CurrentArch.get().uiName()
+        Path jdk17LocalPath = projectDir.toPath().resolve("gradle/jdks/17/${os}/${arch}/local-path")
+        String originalJdk17LocalPath = jdk17LocalPath.text.trim()
+        Path originalJdkPath = Path.of(System.getProperty("user.home")).resolve(".gradle/gradle-jdks")
+                .resolve(originalJdk17LocalPath).toAbsolutePath()
+        !Files.exists(originalJdkPath)
+
+        when: 'trigger a task'
+        jdk17LocalPath.text = "amazon-corretto-${gradleVersion}-test1\n"
+        ExecutionResult executionResult = runTasksSuccessfully("javaToolchains")
+
+        then: 'the jdks are installed by the settings plugin'
+        executionResult.standardError.contains("Gradle JDK setup is enabled (palantir.jdk.setup.enabled is true)" +
+                " but some jdks were not installed")
+        executionResult.standardOutput.contains("Auto-detection:     Disabled")
+        executionResult.standardOutput.contains("Auto-download:      Disabled")
+        executionResult.standardOutput.contains("JDK ${SIMPLIFIED_JDK_17_VERSION}")
+        Path expectedJdkPath = Path.of(System.getProperty("user.home")).resolve(".gradle/gradle-jdks")
+                .resolve("amazon-corretto-${gradleVersion}-test1").toAbsolutePath()
+        Files.exists(expectedJdkPath)
+
+        when: 'if the jdk configured path is changed'
+        jdk17LocalPath.text = "amazon-corretto-${gradleVersion}-test2\n"
+        ExecutionResult resultAfterJdkChange = runTasksSuccessfully("javaToolchains")
+
+        then:
+        resultAfterJdkChange.standardError.contains("Gradle JDK setup is enabled (palantir.jdk.setup.enabled is true)" +
+                " but some jdks were not installed")
+        Path newInstalledJdkPath = Path.of(System.getProperty("user.home")).resolve(".gradle/gradle-jdks")
+                .resolve("amazon-corretto-${gradleVersion}-test2").toAbsolutePath()
+        Files.exists(newInstalledJdkPath)
+
+        cleanup:
+        Files.walk(expectedJdkPath)
+                .sorted(Comparator.reverseOrder())
+                .forEach(Files::delete)
+
+        Files.walk(newInstalledJdkPath)
+                .sorted(Comparator.reverseOrder())
+                .forEach(Files::delete)
+
+        where:
+        gradleVersionNumber << [GradleJdkTestUtils.GRADLE_7_6_VERSION, GradleJdkTestUtils.GRADLE_8_8_VERSION]
+    }
+
+}

--- a/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
+++ b/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
@@ -33,6 +33,7 @@ class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
 
         GradleJdkTestUtils.applyJdksPlugins(settingsFile, buildFile)
 
+
         // language=groovy
         buildFile << """
             jdks {

--- a/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
+++ b/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
@@ -26,10 +26,12 @@ import java.nio.file.Path
 
 class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
 
+    private final Path USER_HOME_PATH = Path.of(System.getProperty("user.home"))
+
     def '#gradleVersionNumber: non-existing jdks are installed by the settings plugin'() {
         setup:
         gradleVersion = gradleVersionNumber
-
+        Files.createDirectories(USER_HOME_PATH)
         GradleJdkTestUtils.applyJdksPlugins(settingsFile, buildFile)
 
         // language=groovy
@@ -69,7 +71,7 @@ class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
         executionResult.standardOutput.contains("Auto-detection:     Disabled")
         executionResult.standardOutput.contains("Auto-download:      Disabled")
         executionResult.standardOutput.contains("JDK ${GradleJdkTestUtils.SIMPLIFIED_JDK_17_VERSION}")
-        Path expectedJdkPath = Path.of(System.getProperty("user.home")).resolve(".gradle/gradle-jdks")
+        Path expectedJdkPath = USER_HOME_PATH.resolve(".gradle/gradle-jdks")
                 .resolve("amazon-corretto-${gradleVersion}-test1").toAbsolutePath()
         Files.exists(expectedJdkPath)
 
@@ -80,7 +82,7 @@ class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
         then:
         resultAfterJdkChange.standardError.contains("Gradle JDK setup is enabled (palantir.jdk.setup.enabled is true)" +
                 " but some jdks were not installed")
-        Path newInstalledJdkPath = Path.of(System.getProperty("user.home")).resolve(".gradle/gradle-jdks")
+        Path newInstalledJdkPath = USER_HOME_PATH.resolve(".gradle/gradle-jdks")
                 .resolve("amazon-corretto-${gradleVersion}-test2").toAbsolutePath()
         Files.exists(newInstalledJdkPath)
 

--- a/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
+++ b/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
@@ -96,6 +96,7 @@ class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
                 .forEach(Files::delete)
 
         where:
+        // testing for the different gradle versions to make sure the reflection in the settings plugin works
         gradleVersionNumber << [GradleJdkTestUtils.GRADLE_7_6_VERSION, GradleJdkTestUtils.GRADLE_8_5_VERSION, GradleJdkTestUtils.GRADLE_8_8_VERSION]
     }
 

--- a/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
+++ b/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
@@ -69,7 +69,7 @@ class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
                 " but some jdks were not installed")
         executionResult.standardOutput.contains("Auto-detection:     Disabled")
         executionResult.standardOutput.contains("Auto-download:      Disabled")
-        executionResult.standardOutput.contains("JDK ${SIMPLIFIED_JDK_17_VERSION}")
+        executionResult.standardOutput.contains("JDK ${GradleJdkTestUtils.SIMPLIFIED_JDK_17_VERSION}")
         Path expectedJdkPath = Path.of(System.getProperty("user.home")).resolve(".gradle/gradle-jdks")
                 .resolve("amazon-corretto-${gradleVersion}-test1").toAbsolutePath()
         Files.exists(expectedJdkPath)
@@ -95,7 +95,7 @@ class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
                 .forEach(Files::delete)
 
         where:
-        gradleVersionNumber << [GradleJdkTestUtils.GRADLE_7_6_VERSION, GradleJdkTestUtils.GRADLE_8_8_VERSION]
+        gradleVersionNumber << [GradleJdkTestUtils.GRADLE_7_6_VERSION, GradleJdkTestUtils.GRADLE_8_5_VERSION, GradleJdkTestUtils.GRADLE_8_8_VERSION]
     }
 
 }

--- a/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
+++ b/gradle-jdks-settings/src/test/groovy/com/palantir/gradle/jdks/settings/ToolchainJdksSettingsPluginTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.palantir.gradle.jdks.settings
 
 import com.palantir.gradle.jdks.GradleJdkTestUtils
@@ -32,7 +31,6 @@ class ToolchainJdksSettingsPluginTest extends IntegrationSpec {
         gradleVersion = gradleVersionNumber
 
         GradleJdkTestUtils.applyJdksPlugins(settingsFile, buildFile)
-
 
         // language=groovy
         buildFile << """

--- a/gradle-jdks-setup-common/src/main/java/com/palantir/gradle/jdks/setup/common/CommandRunner.java
+++ b/gradle-jdks-setup-common/src/main/java/com/palantir/gradle/jdks/setup/common/CommandRunner.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -87,24 +86,6 @@ public final class CommandRunner {
                     String.format("Failed to run command '%s'. ", String.join(" ", processBuilder.command())), e);
         } finally {
             executorService.shutdown();
-        }
-    }
-
-    public static void runWithInheritIO(List<String> commandArguments) {
-        try {
-            ProcessBuilder processBuilder =
-                    new ProcessBuilder().command(commandArguments).redirectErrorStream(true);
-            processBuilder.inheritIO();
-            Process process = processBuilder.start();
-            int exitCode = process.waitFor();
-            if (exitCode != 0) {
-                throw new RuntimeException(String.format(
-                        "Failed to run command '%s'. Failed with exit code %d.",
-                        String.join(" ", commandArguments), exitCode));
-            }
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException(
-                    String.format("Failed to run command '%s'. ", String.join(" ", commandArguments)), e);
         }
     }
 

--- a/gradle-jdks-setup-common/src/main/java/com/palantir/gradle/jdks/setup/common/CommandRunner.java
+++ b/gradle-jdks-setup-common/src/main/java/com/palantir/gradle/jdks/setup/common/CommandRunner.java
@@ -96,7 +96,7 @@ public final class CommandRunner {
         }
     }
 
-    public static Void write(InputStream inputStream, Function<String, Void> logFunction) {
+    public static Void processStream(InputStream inputStream, Function<String, Void> logFunction) {
         try (BufferedReader bufferedReader =
                 new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             String line;

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/CaResources.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/CaResources.java
@@ -117,18 +117,12 @@ public final class CaResources {
         }
     }
 
-    private Void writeStdOutput(InputStream inputStream) {
-        return CommandRunner.processStream(inputStream, line -> {
-            logger.log(line);
-            return null;
-        });
+    private void writeStdOutput(InputStream inputStream) {
+        CommandRunner.processStream(inputStream, logger::log);
     }
 
-    private Void writeStdError(InputStream inputStream) {
-        return CommandRunner.processStream(inputStream, line -> {
-            logger.logError(line);
-            return null;
-        });
+    private void writeStdError(InputStream inputStream) {
+        CommandRunner.processStream(inputStream, logger::logError);
     }
 
     private static boolean isCertificateInTruststore(Path jdkInstallationDirectory, String alias) {

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/CaResources.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/CaResources.java
@@ -110,7 +110,7 @@ public final class CaResources {
                     "-noprompt",
                     "-file",
                     palantirCertFile.getAbsolutePath());
-            CommandRunner.run(importCertificateCommand);
+            CommandRunner.runWithInheritIO(importCertificateCommand);
         } catch (IOException e) {
             throw new RuntimeException("Unable to import the certificate to the jdk", e);
         }

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/CaResources.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/CaResources.java
@@ -118,14 +118,14 @@ public final class CaResources {
     }
 
     private Void writeStdOutput(InputStream inputStream) {
-        return CommandRunner.write(inputStream, line -> {
+        return CommandRunner.processStream(inputStream, line -> {
             logger.log(line);
             return null;
         });
     }
 
     private Void writeStdError(InputStream inputStream) {
-        return CommandRunner.write(inputStream, line -> {
+        return CommandRunner.processStream(inputStream, line -> {
             logger.logError(line);
             return null;
         });

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
@@ -110,6 +110,9 @@ public final class GradleJdkInstallationSetup {
         Path destinationJdkInstallationDir = Path.of(args[1]);
         Path certsDir = Path.of(args[2]);
         boolean wasCopied = copy(logger, destinationJdkInstallationDir);
+        // If the JDK was not copied by the current process - which means that we waited for the lock while another
+        // process set up the JDK - then we shouldn't try to add the certificate because the certificate was already
+        // added.
         if (wasCopied) {
             Map<String, String> certSerialNumbersToNames = extractCertsSerialNumbers(logger, certsDir);
             caResources.maybeImportCertsInJdk(destinationJdkInstallationDir, certSerialNumbersToNames);

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
@@ -92,9 +92,7 @@ public final class GradleJdkInstallationSetup {
         try {
             Files.createDirectories(projectDir.resolve(".gradle"));
             Path gradleConfigFile = projectDir.resolve(".gradle/config.properties");
-            if (!Files.exists(gradleConfigFile)) {
-                Files.createFile(gradleConfigFile);
-            }
+            gradleConfigFile.toFile().createNewFile();
             Properties gradleProperties = new Properties();
             gradleProperties.load(new FileInputStream(gradleConfigFile.toFile()));
             gradleProperties.setProperty("java.home", gradleDaemonJavaHome.toString());

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-setup.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-setup.sh
@@ -58,7 +58,6 @@ do
     esac
 done
 
-APP_BASE_NAME=${0##*/}
 APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 APP_HOME=${APP_HOME%/gradle}
 APP_GRADLE_DIR="$APP_HOME"/gradle
@@ -94,9 +93,9 @@ esac
 if [ "$os_name" = "linux" ]; then
     ldd_output=$(ldd --version 2>&1 || true)
     if echo "$ldd_output" | grep -qi glibc; then
-       os_name="linux-glibc"
+      os_name="linux-glibc"
     elif echo "$ldd_output" | grep -qi "gnu libc"; then
-           os_name="linux-glibc"
+      os_name="linux-glibc"
     elif echo "$ldd_output" | grep -qi musl; then
       os_name="linux-musl"
     else

--- a/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/CommandRunnerTest.java
+++ b/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/CommandRunnerTest.java
@@ -20,19 +20,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.gradle.jdks.setup.common.CommandRunner;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class CommandRunnerTest {
 
     @Test
     public void command_runs_successfully() {
-        assertThat(CommandRunner.run(List.of("echo", "my message"))).contains("my message");
+        assertThat(CommandRunner.runWithOutputCollection(new ProcessBuilder().command("echo", "my message")))
+                .contains("my message");
     }
 
     @Test
     public void command_fails() {
-        assertThatThrownBy(() -> CommandRunner.run(List.of("nonexistingcommand")))
+        assertThatThrownBy(
+                        () -> CommandRunner.runWithOutputCollection(new ProcessBuilder().command("nonexistingcommand")))
                 .hasMessageContaining("Failed to run command 'nonexistingcommand'");
     }
 }

--- a/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/CommandRunnerTest.java
+++ b/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/CommandRunnerTest.java
@@ -41,13 +41,12 @@ public class CommandRunnerTest {
     @Test
     public void command_runs_with_logger() {
         CommandRunner.runWithLogger(
-                new ProcessBuilder().command("echo", "my message"), CommandRunnerTest::assertOutput, _unused -> null);
+                new ProcessBuilder().command("echo", "my message"), CommandRunnerTest::assertOutput, _unused -> {});
     }
 
-    private static Void assertOutput(InputStream inputStream) {
-        return CommandRunner.processStream(inputStream, line -> {
+    private static void assertOutput(InputStream inputStream) {
+        CommandRunner.processStream(inputStream, line -> {
             assertThat(line).contains("my message");
-            return null;
         });
     }
 }

--- a/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/CommandRunnerTest.java
+++ b/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/CommandRunnerTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.gradle.jdks.setup.common.CommandRunner;
+import java.io.InputStream;
 import org.junit.jupiter.api.Test;
 
 public class CommandRunnerTest {
@@ -35,5 +36,18 @@ public class CommandRunnerTest {
         assertThatThrownBy(
                         () -> CommandRunner.runWithOutputCollection(new ProcessBuilder().command("nonexistingcommand")))
                 .hasMessageContaining("Failed to run command 'nonexistingcommand'");
+    }
+
+    @Test
+    public void command_runs_with_logger() {
+        CommandRunner.runWithLogger(
+                new ProcessBuilder().command("echo", "my message"), CommandRunnerTest::assertOutput, _unused -> null);
+    }
+
+    private static Void assertOutput(InputStream inputStream) {
+        return CommandRunner.write(inputStream, line -> {
+            assertThat(line).contains("my message");
+            return null;
+        });
     }
 }

--- a/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/CommandRunnerTest.java
+++ b/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/CommandRunnerTest.java
@@ -45,7 +45,7 @@ public class CommandRunnerTest {
     }
 
     private static Void assertOutput(InputStream inputStream) {
-        return CommandRunner.write(inputStream, line -> {
+        return CommandRunner.processStream(inputStream, line -> {
             assertThat(line).contains("my message");
             return null;
         });

--- a/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupTest.java
+++ b/gradle-jdks-setup/src/test/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupTest.java
@@ -26,7 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -99,14 +98,15 @@ public final class GradleJdkInstallationSetupTest {
     }
 
     private static void checkCaIsImported(Path jdkPath) {
-        CommandRunner.run(List.of(
-                jdkPath.resolve("bin/keytool").toString(),
-                "-list",
-                "-storepass",
-                "changeit",
-                "-alias",
-                AMAZON_CERT_ALIAS,
-                "-keystore",
-                jdkPath.resolve("lib/security/cacerts").toString()));
+        CommandRunner.runWithOutputCollection(new ProcessBuilder()
+                .command(
+                        jdkPath.resolve("bin/keytool").toString(),
+                        "-list",
+                        "-storepass",
+                        "changeit",
+                        "-alias",
+                        AMAZON_CERT_ALIAS,
+                        "-keystore",
+                        jdkPath.resolve("lib/security/cacerts").toString()));
     }
 }

--- a/gradle-jdks-test-common/build.gradle
+++ b/gradle-jdks-test-common/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'java'
+apply plugin: 'groovy'
+
+
+dependencies {
+    implementation project(':gradle-jdks-setup-common')
+    implementation gradleTestKit()
+    implementation 'org.apache.commons:commons-compress'
+}

--- a/gradle-jdks-test-common/build.gradle
+++ b/gradle-jdks-test-common/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'groovy'
 
-
 dependencies {
     implementation project(':gradle-jdks-setup-common')
     implementation gradleTestKit()

--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -76,7 +76,8 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.test {
-    environment("PROJECT_VERSION", project.version)
+    environment(Map.of("PROJECT_VERSION", project.version, "HOME", "/tmp"))
+    systemProperty 'user.home', '/tmp'
     systemProperty 'ignoreDeprecations', 'true'
     dependsOn project(':gradle-jdks-settings').tasks.named('build')
 }

--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     testImplementation gradleTestKit()
     testImplementation project(':gradle-jdks-settings')
+    testImplementation project(':gradle-jdks-test-common')
     testImplementation 'com.netflix.nebula:nebula-test'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core'
@@ -76,8 +77,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.test {
-    environment(Map.of("PROJECT_VERSION", project.version, "HOME", "/tmp"))
-    systemProperty 'user.home', '/tmp'
+    environment(Map.of("PROJECT_VERSION", project.version))
     systemProperty 'ignoreDeprecations', 'true'
     dependsOn project(':gradle-jdks-settings').tasks.named('build')
 }

--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -76,10 +76,10 @@ tasks.withType(JavaCompile).configureEach {
     it.options.errorprone.disable 'StrictUnusedVariable'
 }
 
-tasks.test {
+tasks.withType(Test) {
     environment(Map.of("PROJECT_VERSION", project.version))
     systemProperty 'ignoreDeprecations', 'true'
-    dependsOn project(':gradle-jdks-settings').tasks.named('build')
+    dependsOn project(':gradle-jdks-settings').tasks.withType(PluginUnderTestMetadata.class)
 }
 
 tasks.withType(ProcessResources.class).configureEach {

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkIntegrationSpec.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkIntegrationSpec.groovy
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks
+
+import com.palantir.gradle.jdks.setup.common.CommandRunner
+import nebula.test.IntegrationSpec
+import org.apache.commons.lang3.tuple.Pair
+
+import java.nio.file.Path
+
+abstract class GradleJdkIntegrationSpec extends IntegrationSpec {
+
+    static final List<String> GRADLE_TEST_VERSIONS = [GradleJdkTestUtils.GRADLE_7_6_VERSION, GradleJdkTestUtils.GRADLE_8_8_VERSION]
+
+    abstract Path workingDir();
+
+    def setupJdksHardcodedVersions() {
+        GradleJdkTestUtils.setupJdksHardcodedVersions(settingsFile, buildFile)
+    }
+
+    def applyApplicationPlugin() {
+        GradleJdkTestUtils.applyApplicationPlugin(buildFile)
+    }
+
+    def applyBaselineJavaVersions() {
+        GradleJdkTestUtils.applyBaselineJavaVersions(buildFile)
+    }
+
+    def applyJdksPlugins() {
+        GradleJdkTestUtils.applyJdksPlugins(settingsFile, buildFile)
+    }
+
+    String runGradlewTasksSuccessfully(String... tasks) {
+        String output = runGradlewTasks(tasks)
+        assert output.contains("BUILD SUCCESSFUL")
+        return output
+    }
+
+    String runGradlewTasksWithFailure(String... tasks) {
+        String output = runGradlewTasks(tasks)
+        assert output.contains("BUILD FAILED")
+        return output
+    }
+
+    private String runGradlewTasks(String... tasks) {
+        ProcessBuilder processBuilder = getProcessBuilder(tasks)
+        Process process = processBuilder.start()
+        String output = CommandRunner.readAllInput(process.getInputStream())
+        return output
+    }
+
+    private ProcessBuilder getProcessBuilder(String... tasks) {
+        List<String> arguments = ["./gradlew"]
+        Arrays.asList(tasks).forEach(arguments::add)
+        ProcessBuilder processBuilder = new ProcessBuilder()
+                .command(arguments)
+                .directory(projectDir).redirectErrorStream(true)
+        processBuilder.environment().put("GRADLE_USER_HOME", workingDir().toAbsolutePath().toString())
+        return processBuilder
+    }
+
+    private static final int BYTECODE_IDENTIFIER = (int) 0xCAFEBABE
+
+    // See http://illegalargumentexception.blogspot.com/2009/07/java-finding-class-versions.html
+    static Pair readBytecodeVersion(File file) {
+        try (InputStream stream = new FileInputStream(file)
+             DataInputStream dis = new DataInputStream(stream)) {
+            int magic = dis.readInt()
+            if (magic != BYTECODE_IDENTIFIER) {
+                throw new IllegalArgumentException("File " + file + " does not appear to be java bytecode")
+            }
+            int minorBytecodeVersion = dis.readUnsignedShort()
+            int majorBytecodeVersion = dis.readUnsignedShort()
+            return Pair.of(minorBytecodeVersion, majorBytecodeVersion)
+        }
+    }
+}

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkIntegrationSpec.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkIntegrationSpec.groovy
@@ -32,6 +32,10 @@ abstract class GradleJdkIntegrationSpec extends IntegrationSpec {
         GradleJdkTestUtils.setupJdksHardcodedVersions(settingsFile, buildFile)
     }
 
+    def setupJdksHardcodedVersions(String daemonTarget) {
+        GradleJdkTestUtils.setupJdksHardcodedVersions(settingsFile, buildFile, daemonTarget)
+    }
+
     def applyApplicationPlugin() {
         GradleJdkTestUtils.applyApplicationPlugin(buildFile)
     }

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkIntegrationTest.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkIntegrationTest.groovy
@@ -123,8 +123,7 @@ abstract class GradleJdkIntegrationTest extends IntegrationSpec {
                
                daemonTarget = DAEMON_MAJOR_VERSION_11
             }
-        """.replace("FILES", getBuildPluginClasspathInjector().join(","))
-                .replace("JDK_11_DISTRO", quoted(JDK_11.getLeft()))
+        """.replace("JDK_11_DISTRO", quoted(JDK_11.getLeft()))
                 .replace("JDK_11_VERSION", quoted(JDK_11.getRight()))
                 .replace("JDK_17_DISTRO", quoted(JDK_17.getLeft()))
                 .replace("JDK_17_VERSION", quoted(JDK_17.getRight()))

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkPatcherIntegrationTest.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkPatcherIntegrationTest.groovy
@@ -28,7 +28,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.stream.Collectors
 
-class GradleJdkPatcherIntegrationTest extends GradleJdkIntegrationTest {
+class GradleJdkPatcherIntegrationTest extends GradleJdkIntegrationSpec {
 
     @TempDir
     Path workingDir
@@ -84,7 +84,7 @@ class GradleJdkPatcherIntegrationTest extends GradleJdkIntegrationTest {
         secondCheckResult.wasUpToDate("checkWrapperJdkPatcher")
 
         where:
-        gradleVersionNumber << [GRADLE_7_6_VERSION, GRADLE_7_6_4_VERSION, GRADLE_8_5_VERSION]
+        gradleVersionNumber << GRADLE_TEST_VERSIONS
     }
 
     def '#gradleVersionNumber: fails if Gradle JDK configuration is wrong'() {
@@ -101,7 +101,7 @@ class GradleJdkPatcherIntegrationTest extends GradleJdkIntegrationTest {
         result.standardError.contains("Gradle daemon JDK version is `15` but no JDK configured for that version.")
 
         where:
-        gradleVersionNumber << [GRADLE_7_6_4_VERSION, GRADLE_8_5_VERSION]
+        gradleVersionNumber << GRADLE_TEST_VERSIONS
     }
 
     def '#gradleVersionNumber: fails if no JDKs were configured'() {
@@ -126,7 +126,7 @@ class GradleJdkPatcherIntegrationTest extends GradleJdkIntegrationTest {
         result.standardError.contains("No JDKs were configured for the gradle setup");
 
         where:
-        gradleVersionNumber << [GRADLE_7_6_4_VERSION, GRADLE_8_5_VERSION]
+        gradleVersionNumber << GRADLE_TEST_VERSIONS
     }
 
     def '#gradleVersionNumber: checkGradleJdkConfigs fails if run before setupJdks'() {
@@ -143,7 +143,7 @@ class GradleJdkPatcherIntegrationTest extends GradleJdkIntegrationTest {
         checkResult.standardError.contains("is out of date, please run `./gradlew setupJdks`")
 
         where:
-        gradleVersionNumber << [GRADLE_7_6_4_VERSION, GRADLE_8_5_VERSION]
+        gradleVersionNumber << GRADLE_TEST_VERSIONS
     }
 
     def 'no gradleWrapper patch if palantir.jdk.setup.enabled == false'() {

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkToolchainsIntegrationTest.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkToolchainsIntegrationTest.groovy
@@ -18,20 +18,14 @@ package com.palantir.gradle.jdks
 
 import com.palantir.gradle.jdks.setup.common.CurrentArch
 import com.palantir.gradle.jdks.setup.common.CurrentOs
-import nebula.test.functional.ExecutionResult
 import org.apache.commons.lang3.tuple.Pair
 import spock.lang.TempDir
 
-import java.nio.file.FileVisitResult
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.SimpleFileVisitor
-import java.nio.file.attribute.BasicFileAttributes
 import java.util.regex.Matcher
 import java.util.regex.Pattern
-import java.util.stream.Stream
 
-class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationTest {
+class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationSpec {
 
     private static final int JAVA_11_BYTECODE = 55
     private static final int JAVA_17_BYTECODE = 61
@@ -40,71 +34,6 @@ class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationTest {
 
     @TempDir
     Path workingDir
-
-
-    def '#gradleVersionNumber: non-existing jdks are installed by the settings plugin'() {
-        gradleVersion = gradleVersionNumber
-        applyJdksPlugins()
-
-        // language=groovy
-        buildFile << """
-            jdks {
-               jdk(17) {
-                  distribution = JDK_17_DISTRO
-                  jdkVersion = JDK_17_VERSION
-               }
-               
-                daemonTarget = '17'
-            }
-        """.replace("JDK_17_DISTRO", quoted(JDK_17.getLeft()))
-                .replace("JDK_17_VERSION", quoted(JDK_17.getRight()))
-                .stripIndent(true)
-
-        when:
-        file('gradle.properties') << 'palantir.jdk.setup.enabled=true'
-        runTasksSuccessfully("generateGradleJdkConfigs")
-
-        then: 'only gradle configuration files are generated, no jdks are installed'
-        String os = CurrentOs.get().uiName()
-        String arch = CurrentArch.get().uiName()
-        Path jdk17LocalPath = projectDir.toPath().resolve("gradle/jdks/17/${os}/${arch}/local-path")
-        String compileJdkFileName = jdk17LocalPath.text.trim()
-        Path installedJdkPath = Path.of(System.getProperty("user.home")).resolve(".gradle/gradle-jdks").resolve(compileJdkFileName).toAbsolutePath()
-        !Files.exists(installedJdkPath)
-
-        when: 'trigger a task'
-        ExecutionResult executionResult = runTasksSuccessfully("javaToolchains")
-
-        then: 'the jdks are installed by the settings plugin'
-        executionResult.standardError.contains("Gradle JDK setup is enabled (palantir.jdk.setup.enabled is true)" +
-                " but some jdks were not installed")
-        executionResult.standardOutput.contains("Auto-detection:     Disabled")
-        executionResult.standardOutput.contains("Auto-download:      Disabled")
-        executionResult.standardOutput.contains("JDK ${SIMPLIFIED_JDK_17_VERSION}")
-        Files.exists(installedJdkPath)
-
-        when: 'if the jdk configured path is changed'
-        jdk17LocalPath.text = "amazon-corretto-another-path\n"
-        ExecutionResult resultAfterJdkChange = runTasksSuccessfully("javaToolchains")
-
-        then:
-        resultAfterJdkChange.standardError.contains("Gradle JDK setup is enabled (palantir.jdk.setup.enabled is true)" +
-                " but some jdks were not installed")
-        Path newInstalledJdkPath = Path.of(System.getProperty("user.home")).resolve(".gradle/gradle-jdks").resolve("amazon-corretto-another-path").toAbsolutePath()
-        Files.exists(newInstalledJdkPath)
-
-        cleanup:
-        Files.walk(installedJdkPath)
-                .sorted(Comparator.reverseOrder())
-                .forEach(Files::delete)
-
-        Files.walk(newInstalledJdkPath)
-                .sorted(Comparator.reverseOrder())
-                .forEach(Files::delete)
-
-        where:
-        gradleVersionNumber << [GRADLE_7_6_VERSION]
-    }
 
     def '#gradleVersionNumber: javaToolchains correctly set-up'() {
         gradleVersion = gradleVersionNumber
@@ -136,9 +65,9 @@ class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationTest {
         then: 'the only discovered jdk versions are coming from gradle.properties'
         result.standardOutput.contains("Auto-detection:     Disabled")
         result.standardOutput.contains("Auto-download:      Disabled")
-        result.standardOutput.contains("JDK ${SIMPLIFIED_JDK_11_VERSION}")
-        result.standardOutput.contains("JDK ${SIMPLIFIED_JDK_17_VERSION}")
-        result.standardOutput.contains("JDK ${SIMPLIFIED_JDK_21_VERSION}")
+        result.standardOutput.contains("JDK ${GradleJdkTestUtils.SIMPLIFIED_JDK_11_VERSION}")
+        result.standardOutput.contains("JDK ${GradleJdkTestUtils.SIMPLIFIED_JDK_17_VERSION}")
+        result.standardOutput.contains("JDK ${GradleJdkTestUtils.SIMPLIFIED_JDK_21_VERSION}")
         Matcher matcher = Pattern.compile("Detected by:       (.*)").matcher(result.standardOutput)
         while (matcher.find()) {
             String detectedByPattern = matcher.group(1)
@@ -151,7 +80,7 @@ class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationTest {
         then: 'java home is set to out jdk 11 configured version'
         String os = CurrentOs.get().uiName()
         String arch = CurrentArch.get().uiName()
-        String daemonJdkFileName = projectDir.toPath().resolve("gradle/jdks/${DAEMON_MAJOR_VERSION_11}/${os}/${arch}/local-path").text.trim()
+        String daemonJdkFileName = projectDir.toPath().resolve("gradle/jdks/${GradleJdkTestUtils.DAEMON_MAJOR_VERSION_11}/${os}/${arch}/local-path").text.trim()
         Path daemonJvm = workingDir().resolve("gradle-jdks").resolve(daemonJdkFileName).toAbsolutePath()
         gradleHomeOutput.contains("java.home: ${daemonJvm}")
 
@@ -171,7 +100,7 @@ class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationTest {
         runOutput.contains("Java home: ${compileJvm}")
 
         where:
-        gradleVersionNumber << [GRADLE_7_6_VERSION, GRADLE_7_6_4_VERSION, GRADLE_8_5_VERSION, GRADLE_8_8_VERSION]
+        gradleVersionNumber << GRADLE_TEST_VERSIONS
     }
 
 
@@ -243,7 +172,7 @@ class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationTest {
         readBytecodeVersion(subproject21Class) == Pair.of(0, JAVA_21_BYTECODE)
 
         where:
-        gradleVersionNumber << [GRADLE_7_6_4_VERSION, GRADLE_8_5_VERSION]
+        gradleVersionNumber << GRADLE_TEST_VERSIONS
     }
 
     def '#gradleVersionNumber: fails if the jdk version is not configured'() {
@@ -270,8 +199,8 @@ class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationTest {
 
         where:
         gradleVersionNumber  | expectedErrorLines
-        GRADLE_7_6_4_VERSION | ["No compatible toolchains found for request specification: {languageVersion=15, vendor=any, implementation=vendor-specific} (auto-detect false, auto-download false)."]
-        GRADLE_8_5_VERSION   | ["No matching toolchains found for requested specification: {languageVersion=15, vendor=any, implementation=vendor-specific}", "No locally installed toolchains match and toolchain auto-provisioning is not enabled."]
+        GradleJdkTestUtils.GRADLE_7_6_4_VERSION | ["No compatible toolchains found for request specification: {languageVersion=15, vendor=any, implementation=vendor-specific} (auto-detect false, auto-download false)."]
+        GradleJdkTestUtils.GRADLE_8_5_VERSION   | ["No matching toolchains found for requested specification: {languageVersion=15, vendor=any, implementation=vendor-specific}", "No locally installed toolchains match and toolchain auto-provisioning is not enabled."]
     }
 
     def java17PreviewCode = '''

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkToolchainsIntegrationTest.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkToolchainsIntegrationTest.groovy
@@ -152,7 +152,7 @@ class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationSpec {
         then: 'java home is set to out jdk 11 configured version'
         String os = CurrentOs.get().uiName()
         String arch = CurrentArch.get().uiName()
-        String daemonJdkFileName = projectDir.toPath().resolve("gradle/jdks/${DAEMON_MAJOR_VERSION_11}/${os}/${arch}/local-path").text.trim()
+        String daemonJdkFileName = projectDir.toPath().resolve("gradle/jdks/${GradleJdkTestUtils.DAEMON_MAJOR_VERSION_11}/${os}/${arch}/local-path").text.trim()
         Path daemonJvm = workingDir().resolve("gradle-jdks").resolve(daemonJdkFileName).toAbsolutePath()
         gradleHomeOutput.contains("java.home: ${daemonJvm}")
 

--- a/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksProjectService.java
+++ b/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksProjectService.java
@@ -95,6 +95,7 @@ public final class GradleJdksProjectService {
 
     private void setupGradleJdks() {
         try {
+            consoleView.get().clear();
             GeneralCommandLine cli =
                     new GeneralCommandLine("./gradle/gradle-jdks-setup.sh").withWorkDirectory(project.getBasePath());
             OSProcessHandler handler = new OSProcessHandler(cli);
@@ -106,7 +107,7 @@ public final class GradleJdksProjectService {
                 }
             });
             consoleView.get().attachToProcess(handler);
-            ProcessTerminatedListener.attach(handler, project);
+            ProcessTerminatedListener.attach(handler, project, "Gradle JDK setup finished with exit code $EXIT_CODE$");
             handler.waitFor();
         } catch (ExecutionException e) {
             throw new RuntimeException("Failed to setup Gradle JDKs for Intellij", e);

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,4 @@ include 'idea-plugin'
 include 'gradle-jdks-settings'
 include 'gradle-jdks-groovy'
 include 'gradle-jdks-enablement'
-
+include 'gradle-jdks-test-common'


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
If a user didn't have the Intellij plugin `palantir-gradle-jdks` installed and if one of the jdks is not installed, they would get a failure in Intellij saying [Failed to find the toolchain at path= ...](https://github.com/palantir/gradle-jdks/compare/cr/fix-settings?expand=1#diff-1eebe5a89ca91bcce8ee9203a78fef241ebe4f6b593f82fa8b5e45fee28dbbe9L170). It isn't clear how to unblock.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
- If one of the configured jdks is not installed, the settings plugin will call the `gradle/gradle-jdks-setup.sh` script. Thsi should only happen if the developer doesn't have the Intellij plugin installed.
- [Small cleanup, happy to move it to another PR] Changed the default log message for the Intellij Gradle JDK setup configuration run. Default was: [Process finished with exit code](https://github.com/xunfeng1980/intellij-community/blob/1812072b842bb808d84eb1b71fbd1ab6bd84cdf6/platform/ide-core/src/com/intellij/execution/process/ProcessTerminatedListener.java#L41C45-L41C81)
<img width="446" alt="Screenshot 2024-07-17 at 6 29 14 PM" src="https://github.com/user-attachments/assets/6370a83d-fabc-4057-bc46-38cd0784e577">

==COMMIT_MSG==
[Gradle JDK] Fix when `palantir-gradle-jdks` is not installed and jdks are missing
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

