### PR TITLE
Add `/usr/java/$java_version` symlink to `install-jdks.sh` excavator script

### DIFF
--- a/changelog/@unreleased/pr-386.v2.yml
+++ b/changelog/@unreleased/pr-386.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Add `/usr/java/$java_version` symlink to `install-jdks.sh` excavator
+    script
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/386

--- a/gradle-jdks-excavator-configurations/src/main/resources/install-jdks.sh
+++ b/gradle-jdks-excavator-configurations/src/main/resources/install-jdks.sh
@@ -10,6 +10,10 @@ CERTS_DIR=$2
 SYMLINK_PATTERN=$3
 JAVA_SYMLINK_DIR=${4:-/usr/java}
 
+symlink_dir="${SYMLINK_PATTERN%/*}"
+mkdir -p "$symlink_dir"
+mkdir -p "$JAVA_SYMLINK_DIR"
+
 # Loading gradle jdk functions
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTS_DIR"/gradle-jdks-functions.sh

--- a/gradle-jdks-excavator-configurations/src/main/resources/install-jdks.sh
+++ b/gradle-jdks-excavator-configurations/src/main/resources/install-jdks.sh
@@ -8,6 +8,8 @@ CERTS_DIR=$2
 # used by the resolved_symlink below to resolve the path based on the JAVA_VERSION value. e.g. /usr/local/${JAVA_VERSION}
 # shellcheck disable=SC2034
 SYMLINK_PATTERN=$3
+JAVA_SYMLINK_DIR=${4:-/usr/java}
+
 
 # Loading gradle jdk functions
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -27,6 +29,9 @@ for dir in "$GRADLE_DIR"/jdks/*/; do
   resolved_symlink="${SYMLINK_PATTERN//\$\{JAVA_VERSION\}/$major_version}"
   # shellcheck disable=SC2154
   ln -s "$jdk_installation_directory" "$resolved_symlink"
+  # Link java installations to /usr/java so that installations are automatically picked up by gradle
+  ## https://github.com/gradle/gradle/blob/b381099260a04f226ef2412db8ee38fae3e9e753/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java#L46
+  ln -s "$jdk_installation_directory" "$JAVA_SYMLINK_DIR/$major_version"
 done
 
 cleanup

--- a/gradle-jdks-excavator-configurations/src/main/resources/install-jdks.sh
+++ b/gradle-jdks-excavator-configurations/src/main/resources/install-jdks.sh
@@ -10,7 +10,6 @@ CERTS_DIR=$2
 SYMLINK_PATTERN=$3
 JAVA_SYMLINK_DIR=${4:-/usr/java}
 
-
 # Loading gradle jdk functions
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTS_DIR"/gradle-jdks-functions.sh

--- a/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
+++ b/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
@@ -89,7 +89,8 @@ class GradleJdksConfiguratorTest {
                         symlinkDir.toAbsolutePath().resolve("usr/java").toString());
         Path installationJdkDir = latestGradleJdksDir.resolve("installed-jdks");
         processBuilder.environment().put("GRADLE_USER_HOME", installationJdkDir.toString());
-        CommandRunner.runWithOutputCollection(processBuilder);
+        String output = CommandRunner.runWithOutputCollection(processBuilder);
+        assertThat(output).isEqualTo("dasdas");
         Path installedJdkPath = installationJdkDir.resolve("gradle-jdks").resolve(localPath.trim());
         ProcessBuilder runJavaCommand = new ProcessBuilder()
                 .command(findJavaExec(installedJdkPath).toAbsolutePath().toString(), "-version")

--- a/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
+++ b/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
@@ -89,7 +89,7 @@ class GradleJdksConfiguratorTest {
                         symlinkDir.toAbsolutePath().resolve("usr/java").toString());
         Path installationJdkDir = latestGradleJdksDir.resolve("installed-jdks");
         processBuilder.environment().put("GRADLE_USER_HOME", installationJdkDir.toString());
-        String output = CommandRunner.runWithOutputCollection(processBuilder);
+        CommandRunner.runWithOutputCollection(processBuilder);
         Path installedJdkPath = installationJdkDir.resolve("gradle-jdks").resolve(localPath.trim());
         ProcessBuilder runJavaCommand = new ProcessBuilder()
                 .command(findJavaExec(installedJdkPath).toAbsolutePath().toString(), "-version")

--- a/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
+++ b/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
@@ -107,5 +107,4 @@ class GradleJdksConfiguratorTest {
                     .orElseThrow(() -> new RuntimeException("Could not find java executable in " + javaHome));
         }
     }
-
 }

--- a/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
+++ b/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
@@ -90,7 +90,6 @@ class GradleJdksConfiguratorTest {
         Path installationJdkDir = latestGradleJdksDir.resolve("installed-jdks");
         processBuilder.environment().put("GRADLE_USER_HOME", installationJdkDir.toString());
         String output = CommandRunner.runWithOutputCollection(processBuilder);
-        assertThat(output).isEqualTo("dasdas");
         Path installedJdkPath = installationJdkDir.resolve("gradle-jdks").resolve(localPath.trim());
         ProcessBuilder runJavaCommand = new ProcessBuilder()
                 .command(findJavaExec(installedJdkPath).toAbsolutePath().toString(), "-version")

--- a/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
+++ b/gradle-jdks-excavator-configurations/src/test/java/com/palantir/gradle/jdks/GradleJdksConfiguratorTest.java
@@ -85,7 +85,8 @@ class GradleJdksConfiguratorTest {
                         installationScript.toAbsolutePath().toString(),
                         latestGradleJdksDir.toString(),
                         certsDir.toString(),
-                        symlinkDir.toAbsolutePath() + "/java${JAVA_VERSION}");
+                        symlinkDir.toAbsolutePath() + "/java${JAVA_VERSION}",
+                        symlinkDir.toAbsolutePath().resolve("usr/java").toString());
         Path installationJdkDir = latestGradleJdksDir.resolve("installed-jdks");
         processBuilder.environment().put("GRADLE_USER_HOME", installationJdkDir.toString());
         CommandRunner.runWithOutputCollection(processBuilder);
@@ -96,6 +97,7 @@ class GradleJdksConfiguratorTest {
         assertThat(CommandRunner.runWithOutputCollection(runJavaCommand))
                 .contains(String.format("Corretto-%s", JDK_VERSION));
         assertThat(symlinkDir.resolve("java21").toRealPath()).isEqualTo(installedJdkPath.toRealPath());
+        assertThat(symlinkDir.resolve("usr/java/21").toRealPath()).isEqualTo(installedJdkPath.toRealPath());
     }
 
     private static Path findJavaExec(Path javaHome) throws IOException {
@@ -105,4 +107,5 @@ class GradleJdksConfiguratorTest {
                     .orElseThrow(() -> new RuntimeException("Could not find java executable in " + javaHome));
         }
     }
+
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
If autoDetection is enabled, Gradle is only searching for java executables in the directories: https://github.com/gradle/gradle/blob/80477c69ff426af47b53cda7f3167ad188935727/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java#L36.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Adding a symlink for the installed jdks in the `/usr/java` directory.

==COMMIT_MSG==
Add `/usr/java/$java_version` symlink to `install-jdks.sh` excavator script
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

