### PR TITLE
Write the minimum version for the `palantir-gradle-jdks` intellij plugin

### DIFF
--- a/changelog/@unreleased/pr-396.v2.yml
+++ b/changelog/@unreleased/pr-396.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Write the minimum version for the `palantir-gradle-jdks` intellij plugin
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/396

--- a/gradle-jdks-groovy/build.gradle
+++ b/gradle-jdks-groovy/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 
 dependencies {
-    testImplementation gradleTestKit()
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core'
 }

--- a/gradle-jdks-groovy/build.gradle
+++ b/gradle-jdks-groovy/build.gradle
@@ -1,3 +1,10 @@
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'groovy'
 apply plugin: 'com.palantir.external-publish-jar'
+
+
+dependencies {
+    testImplementation gradleTestKit()
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.assertj:assertj-core'
+}

--- a/gradle-jdks-groovy/src/test/groovy/com/palantir/gradle/jdks/ConfigureJdksIdeaPluginXmlTest.groovy
+++ b/gradle-jdks-groovy/src/test/groovy/com/palantir/gradle/jdks/ConfigureJdksIdeaPluginXmlTest.groovy
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks
+
+import org.junit.jupiter.api.Test
+
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.file.Files
+
+class ConfigureJdksIdeaPluginXmlTest {
+
+    @Test
+    void can_update_externalDependencies_file() {
+        File tmpDir = File.createTempDir()
+        Path tmpFile = tmpDir.toPath().resolve("externalDependencies.xml")
+        ConfigureJdksIdeaPluginXml.updateIdeaXmlFile(tmpFile.toFile(), "0.1.0", true)
+        assertThat(Files.readAllLines(tmpFile))
+                .anyMatch { line -> line.contains("<plugin id=\"palantir-gradle-jdks\" min-version=\"0.1.0\"/>")}
+        ConfigureJdksIdeaPluginXml.updateIdeaXmlFile(tmpFile.toFile(), "0.2.0", true)
+        assertThat(tmpFile.text).isEqualTo(Path.of("src/test/resources/expected-externalDependencies.xml").text)
+    }
+}

--- a/gradle-jdks-groovy/src/test/resources/expected-externalDependencies.xml
+++ b/gradle-jdks-groovy/src/test/resources/expected-externalDependencies.xml
@@ -1,0 +1,5 @@
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="palantir-gradle-jdks" min-version="0.2.0"/>
+  </component>
+</project>

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/PalantirGradleJdksIdeaPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/PalantirGradleJdksIdeaPlugin.java
@@ -17,27 +17,15 @@
 package com.palantir.gradle.jdks;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
-import groovy.util.Node;
-import groovy.xml.XmlNodePrinter;
-import groovy.xml.XmlParser;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.function.Consumer;
-import javax.xml.parsers.ParserConfigurationException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.xml.sax.SAXException;
 
 public class PalantirGradleJdksIdeaPlugin implements Plugin<Project> {
 
     private static final Logger logger = Logging.getLogger(ToolchainsPlugin.class);
+    private static final String MIN_IDEA_PLUGIN_VERSION = "0.44.0";
 
     @Override
     public final void apply(Project rootProject) {
@@ -58,49 +46,12 @@ public class PalantirGradleJdksIdeaPlugin implements Plugin<Project> {
             return;
         }
         project.getGradle().projectsEvaluated(gradle -> {
-            createOrUpdateIdeaXmlFile(
-                    project.file(".idea/externalDependencies.xml"),
-                    ConfigureJdksIdeaPluginXml::configureExternalDependencies);
+            ConfigureJdksIdeaPluginXml.updateIdeaXmlFile(
+                    project.file(".idea/externalDependencies.xml"), MIN_IDEA_PLUGIN_VERSION, true);
 
             // Still configure legacy idea if using intellij import
-            updateIdeaXmlFileIfExists(
-                    project.file(project.getName() + ".ipr"),
-                    ConfigureJdksIdeaPluginXml::configureExternalDependencies);
+            ConfigureJdksIdeaPluginXml.updateIdeaXmlFile(
+                    project.file(project.getName() + ".ipr"), MIN_IDEA_PLUGIN_VERSION, false);
         });
-    }
-
-    private static void createOrUpdateIdeaXmlFile(File configurationFile, Consumer<Node> configure) {
-        updateIdeaXmlFile(configurationFile, configure, true);
-    }
-
-    private static void updateIdeaXmlFileIfExists(File configurationFile, Consumer<Node> configure) {
-        updateIdeaXmlFile(configurationFile, configure, false);
-    }
-
-    private static void updateIdeaXmlFile(File configurationFile, Consumer<Node> configure, boolean createIfAbsent) {
-        Node rootNode;
-        if (configurationFile.isFile()) {
-            try {
-                rootNode = new XmlParser().parse(configurationFile);
-            } catch (IOException | SAXException | ParserConfigurationException e) {
-                throw new RuntimeException("Couldn't parse existing configuration file: " + configurationFile, e);
-            }
-        } else {
-            if (!createIfAbsent) {
-                return;
-            }
-            rootNode = new Node(null, "project", ImmutableMap.of("version", "4"));
-        }
-
-        configure.accept(rootNode);
-
-        try (BufferedWriter writer = Files.newWriter(configurationFile, StandardCharsets.UTF_8);
-                PrintWriter printWriter = new PrintWriter(writer)) {
-            XmlNodePrinter nodePrinter = new XmlNodePrinter(printWriter);
-            nodePrinter.setPreserveWhitespace(true);
-            nodePrinter.print(rootNode);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to write back to configuration file: " + configurationFile, e);
-        }
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
The version of the `gradle-jdks` plugin will enforce the minimum version of the `palantir-gradle-jdks` Intellij plugin. This makes sure that breaking changes to the `gradle-jdks` logic will work correctly in Intellij (provided that the Intellij plugin is backwards compatible). 

This makes it possible in the future  to remove the need to update the `.gradle/config.properties` file in the `gradle-jdks` plugin (that is used by the Intellij plugin atm to set the `gradleJvm` tp `GRADLE_LOCAL_USER_HOME`) and instead have the Intellij plugin configure the gradleJvm directly to an SDK. 


<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Write the minimum version for the `palantir-gradle-jdks` intellij plugin
==COMMIT_MSG==

FLUPS:
- I think this logic might make sense to be moved to a common library that other idea plugins can use as well (e.g. palantir-java-format or withcraft-logging)
- Add logic to the intellij plugin to loudly fail if the current plugin version < min-version
## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

