### PR TITLE
Use com.palantir.external-publish-intellij for idea plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.46.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.15.0'
         classpath 'org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:4.1.0'
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.17.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.18.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.50.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.23.0'
         classpath 'com.palantir.gradle.shadow-jar:gradle-shadow-jar:2.8.0'
@@ -22,7 +22,6 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "1.17.3" apply false
     id 'org.jetbrains.gradle.plugin.idea-ext' version "1.1.1"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,6 @@ buildscript {
     }
 }
 
-plugins {
-    id 'org.jetbrains.gradle.plugin.idea-ext' version "1.1.1"
-}
-
 apply plugin: 'com.palantir.external-publish'
 apply plugin: 'com.palantir.git-version'
 apply plugin: 'com.palantir.consistent-versions'

--- a/changelog/@unreleased/pr-408.v2.yml
+++ b/changelog/@unreleased/pr-408.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use com.palantir.external-publish-intellij for idea plugins
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/408

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'java'
-apply plugin: 'maven-publish'
-apply plugin: 'org.jetbrains.intellij'
-apply plugin: 'com.palantir.external-publish-jar'
+apply plugin: 'com.palantir.external-publish-intellij'
 
 intellij {
     pluginName = "gradle-jdks"
@@ -10,61 +8,18 @@ intellij {
     plugins = ['java', 'org.jetbrains.plugins.gradle']
 }
 
-def buildPlugin = tasks.named("buildPlugin")
-
 patchPluginXml {
     pluginDescription = "Configures the Gradle JDKs for the Toolchains used for a project and for the Gradle Daemon."
-    version = project.version
     sinceBuild = '241' // TODO: test against this version of IntelliJ to ensure no regressions
     untilBuild = ''
-}
-
-tasks.named("runIde") {
-    // Allow debugging
-    jvmArgs '--add-exports=java.base/jdk.internal.vm=ALL-UNNAMED'
-
-    dependsOn(buildPlugin)
-}
-
-def publishPlugin = tasks.named("publishPlugin") {
-    onlyIf { versionDetails().isCleanTag }
-
-    token = System.env.JETBRAINS_PLUGIN_REPO_TOKEN
-}
-tasks.named("publish") {
-    dependsOn(publishPlugin)
 }
 
 dependencies {
     implementation project(':gradle-jdks-setup-common')
     implementation project(':gradle-jdks-enablement')
-    
+
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
-}
-
-tasks.named("check") {
-    dependsOn(buildPlugin, tasks.named("verifyPlugin"))
-}
-
-tasks.named("buildSearchableOptions") {
-    enabled = false
-}
-
-// Prevent nebula.maven-publish from trying to publish components.java - we are publishing our own different artifact
-ext."nebulaPublish.maven.jar" = false
-
-publishing {
-    publications {
-        nebula(MavenPublication) {
-            artifact buildPlugin
-        }
-    }
-}
-
-versionsLock {
-    // 'org.jetbrains.intellij' creates a dependency on *IntelliJ*, which GCV cannot resolve
-    disableJavaPluginDefaults()
 }
 
 // Javadoc fails if there are no public classes to javadoc, so make it stop complaining.


### PR DESCRIPTION
## Before this PR
Had the same copy and pasted block of code for publishing intellij plugins which was not centrally managed

## After this PR
Migrated to the `com.palantir.external-publish-intellij` plugin to handle the publication of intellij plugins