### PR TITLE
Intellij plugin doesn't need IDE restart anymore

### DIFF
--- a/gradle-jdks-enablement/src/main/java/com/palantir/gradle/jdks/enablement/GradleJdksEnablement.java
+++ b/gradle-jdks-enablement/src/main/java/com/palantir/gradle/jdks/enablement/GradleJdksEnablement.java
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Properties;
 
-public class GradleJdksEnablement {
+public final class GradleJdksEnablement {
 
     public static final String MINIMUM_SUPPORTED_GRADLE_VERSION = "7.6";
 

--- a/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksProjectService.java
+++ b/idea-plugin/src/main/java/com/palantir/gradle/jdks/GradleJdksProjectService.java
@@ -65,7 +65,7 @@ public final class GradleJdksProjectService implements Disposable {
     private final Project project;
     private final Supplier<ConsoleView> consoleView = Suppliers.memoize(this::initConsoleView);
 
-    private GradleJdksProjectService(Project project) {
+    public GradleJdksProjectService(Project project) {
         this.project = project;
     }
 

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin url="https://github.com/palantir/gradle-jdks">
+<idea-plugin url="https://github.com/palantir/gradle-jdks" require-restart="false">
   <id>palantir-gradle-jdks</id>
   <name>palantir-gradle-jdks</name>
   <vendor url="https://github.com/palantir/gradle-jdks">


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Any update of the palantir-gradle-jdk plugin needed a restart of Intellij. 

## After this PR
In preparation for https://github.com/palantir/gradle-jdks/pull/410 (prompting the user to update the version of the plugin), we are making the plugin dynamic (https://plugins.jetbrains.com/docs/intellij/dynamic-plugins.html) such that upgrading the plugin version won't need a restart of the IDE anymore. 

==COMMIT_MSG==
Intellij plugin doesn't need IDE restart anymore
==COMMIT_MSG==

## Possible downsides?
Not possible to test updating the plugin using `./gradlew runIde`. I ran the verification as per https://plugins.jetbrains.com/docs/intellij/dynamic-plugins.html#restrictions & ade sure we are cleaning up all the resources (https://plugins.jetbrains.com/docs/intellij/dynamic-plugins.html#resource-cleanup).
<!-- Please describe any way users could be negatively affected by this PR. -->

