### PR TITLE
[Fix] JDK is successfully installed if `bin/java` files exist

### DIFF
--- a/changelog/@unreleased/pr-452.v2.yml
+++ b/changelog/@unreleased/pr-452.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[Fix] JDK is successfully installed if `bin/java` exists'
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/452

--- a/changelog/@unreleased/pr-452.v2.yml
+++ b/changelog/@unreleased/pr-452.v2.yml
@@ -1,5 +1,6 @@
 type: fix
 fix:
-  description: '[Fix] JDK is successfully installed if `bin/java` exists'
+  description: '[Fix] JDK is successfully installed if bin/java or sentinel files
+    exist'
   links:
   - https://github.com/palantir/gradle-jdks/pull/452

--- a/gradle-jdks-setup/src/integrationTest/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupIntegrationTest.java
+++ b/gradle-jdks-setup/src/integrationTest/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupIntegrationTest.java
@@ -19,7 +19,6 @@ package com.palantir.gradle.jdks.setup;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.palantir.gradle.jdks.AmazonCorrettoJdkDistribution;
 import com.palantir.gradle.jdks.JdkPath;
@@ -44,7 +43,6 @@ public class GradleJdkInstallationSetupIntegrationTest {
 
     private static final String JDK_VERSION = "11.0.21.9.1";
     private static final Arch ARCH = CurrentArch.get();
-    private static final Optional<Path> NO_MOUNT = Optional.empty();
     private static final String CORRETTO_DISTRIBUTION_URL_ENV = "CORRETTO_DISTRIBUTION_URL";
     private static final AmazonCorrettoJdkDistribution CORRETTO_JDK_DISTRIBUTION = new AmazonCorrettoJdkDistribution();
     private static final boolean DO_NOT_INSTALL_CURL = false;
@@ -56,26 +54,25 @@ public class GradleJdkInstallationSetupIntegrationTest {
     @Test
     public void can_setup_jdks_centos() throws IOException, InterruptedException {
         setupGradleDirectoryStructure(Os.LINUX_GLIBC);
-        dockerBuildAndRunTestingScript("centos:7", "/bin/bash", DO_NOT_INSTALL_CURL, NO_MOUNT);
+        dockerBuildAndRunTestingScript("centos:7", "/bin/bash", DO_NOT_INSTALL_CURL, false);
     }
 
     @Test
     public void can_setup_jdks_ubuntu() throws IOException, InterruptedException {
         setupGradleDirectoryStructure(Os.LINUX_GLIBC);
-        dockerBuildAndRunTestingScript("ubuntu:20.04", "/bin/bash", INSTALL_CURL, NO_MOUNT);
+        dockerBuildAndRunTestingScript("ubuntu:20.04", "/bin/bash", INSTALL_CURL, false);
     }
 
     @Test
     public void can_reinstall_jdks_ubuntu() throws IOException, InterruptedException {
         setupGradleDirectoryStructure(Os.LINUX_GLIBC);
-        Path dir = Files.createDirectories(workingDir.resolve("amazon-corretto-11.0.21.9.1"));
-        dockerBuildAndRunTestingScript("ubuntu:20.04", "/bin/bash", INSTALL_CURL, Optional.of(dir));
+        dockerBuildAndRunTestingScript("ubuntu:20.04", "/bin/bash", INSTALL_CURL, true);
     }
 
     @Test
     public void can_setup_jdks_alpine() throws IOException, InterruptedException {
         setupGradleDirectoryStructure(Os.LINUX_MUSL);
-        dockerBuildAndRunTestingScript("alpine:3.16.0", "/bin/sh", DO_NOT_INSTALL_CURL, NO_MOUNT);
+        dockerBuildAndRunTestingScript("alpine:3.16.0", "/bin/sh", DO_NOT_INSTALL_CURL, false);
     }
 
     private Path setupGradleDirectoryStructure(Os os) throws IOException {
@@ -163,7 +160,7 @@ public class GradleJdkInstallationSetupIntegrationTest {
     }
 
     private void dockerBuildAndRunTestingScript(
-            String baseImage, String shell, boolean installCurl, Optional<Path> mountGradleJdkDir)
+            String baseImage, String shell, boolean installCurl, boolean addEmptyGradleJdkDir)
             throws IOException, InterruptedException {
         Path dockerFile = Path.of("src/integrationTest/resources/template.Dockerfile");
         String dockerImage = String.format("jdk-test-%s", baseImage);
@@ -176,17 +173,16 @@ public class GradleJdkInstallationSetupIntegrationTest {
                 String.format("INSTALL_CURL=%s", installCurl),
                 "--build-arg",
                 String.format("SCRIPT_SHELL=%s", shell),
+                "--build-arg",
+                String.format("INSTALL_CURL=%s", addEmptyGradleJdkDir),
                 "-t",
                 dockerImage,
                 "-f",
                 dockerFile.toAbsolutePath().toString(),
                 workingDir.toAbsolutePath().toString()));
 
-        ImmutableList.Builder runCommand = ImmutableList.builder().add("docker", "run");
-        mountGradleJdkDir.ifPresent(dir -> runCommand.add(
-                "-v", String.format("%s:/root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1", dir.toAbsolutePath())));
-        runCommand.add("--rm", dockerImage, shell, "/testing-script.sh");
-        assertThat(runCommandWithZeroExitCode(runCommand.build()))
+        assertThat(runCommandWithZeroExitCode(
+                        List.of("docker", "run", "--rm", dockerImage, shell, "/testing-script.sh")))
                 .contains("openjdk version \"11.0.21\"")
                 .contains("JAVA_HOME is set to: /root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1");
     }

--- a/gradle-jdks-setup/src/integrationTest/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupIntegrationTest.java
+++ b/gradle-jdks-setup/src/integrationTest/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupIntegrationTest.java
@@ -159,8 +159,7 @@ public class GradleJdkInstallationSetupIntegrationTest {
         Files.writeString(path, content + "\n");
     }
 
-    private void dockerBuildAndRunTestingScript(
-            String baseImage, String shell, boolean installCurl, boolean addEmptyGradleJdkDir)
+    private void dockerBuildAndRunTestingScript(String baseImage, String shell, boolean installCurl, boolean addJdkDir)
             throws IOException, InterruptedException {
         Path dockerFile = Path.of("src/integrationTest/resources/template.Dockerfile");
         String dockerImage = String.format("jdk-test-%s", baseImage);
@@ -174,7 +173,7 @@ public class GradleJdkInstallationSetupIntegrationTest {
                 "--build-arg",
                 String.format("SCRIPT_SHELL=%s", shell),
                 "--build-arg",
-                String.format("EMPTY_GRADLE_JDK_DIR=%s", addEmptyGradleJdkDir),
+                String.format("ADD_JDK_DIR=%s", addJdkDir),
                 "-t",
                 dockerImage,
                 "-f",

--- a/gradle-jdks-setup/src/integrationTest/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupIntegrationTest.java
+++ b/gradle-jdks-setup/src/integrationTest/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupIntegrationTest.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.jdks.setup;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.palantir.gradle.jdks.AmazonCorrettoJdkDistribution;
 import com.palantir.gradle.jdks.JdkPath;
@@ -43,6 +44,7 @@ public class GradleJdkInstallationSetupIntegrationTest {
 
     private static final String JDK_VERSION = "11.0.21.9.1";
     private static final Arch ARCH = CurrentArch.get();
+    private static final Optional<Path> NO_MOUNT = Optional.empty();
     private static final String CORRETTO_DISTRIBUTION_URL_ENV = "CORRETTO_DISTRIBUTION_URL";
     private static final AmazonCorrettoJdkDistribution CORRETTO_JDK_DISTRIBUTION = new AmazonCorrettoJdkDistribution();
     private static final boolean DO_NOT_INSTALL_CURL = false;
@@ -52,21 +54,28 @@ public class GradleJdkInstallationSetupIntegrationTest {
     private Path workingDir;
 
     @Test
-    public void can_setup_jdk_with_certs_centos() throws IOException, InterruptedException {
+    public void can_setup_jdks_centos() throws IOException, InterruptedException {
         setupGradleDirectoryStructure(Os.LINUX_GLIBC);
-        dockerBuildAndRunTestingScript("centos:7", "/bin/bash", DO_NOT_INSTALL_CURL);
+        dockerBuildAndRunTestingScript("centos:7", "/bin/bash", DO_NOT_INSTALL_CURL, NO_MOUNT);
     }
 
     @Test
-    public void can_setup_jdk_with_certs_ubuntu() throws IOException, InterruptedException {
+    public void can_setup_jdks_ubuntu() throws IOException, InterruptedException {
         setupGradleDirectoryStructure(Os.LINUX_GLIBC);
-        dockerBuildAndRunTestingScript("ubuntu:20.04", "/bin/bash", INSTALL_CURL);
+        dockerBuildAndRunTestingScript("ubuntu:20.04", "/bin/bash", INSTALL_CURL, NO_MOUNT);
     }
 
     @Test
-    public void can_setup_jdk_with_certs_alpine() throws IOException, InterruptedException {
+    public void can_reinstall_jdks_ubuntu() throws IOException, InterruptedException {
+        setupGradleDirectoryStructure(Os.LINUX_GLIBC);
+        Path dir = Files.createDirectories(workingDir.resolve("amazon-corretto-11.0.21.9.1"));
+        dockerBuildAndRunTestingScript("ubuntu:20.04", "/bin/bash", INSTALL_CURL, Optional.of(dir));
+    }
+
+    @Test
+    public void can_setup_jdks_alpine() throws IOException, InterruptedException {
         setupGradleDirectoryStructure(Os.LINUX_MUSL);
-        dockerBuildAndRunTestingScript("alpine:3.16.0", "/bin/sh", DO_NOT_INSTALL_CURL);
+        dockerBuildAndRunTestingScript("alpine:3.16.0", "/bin/sh", DO_NOT_INSTALL_CURL, NO_MOUNT);
     }
 
     private Path setupGradleDirectoryStructure(Os os) throws IOException {
@@ -153,7 +162,8 @@ public class GradleJdkInstallationSetupIntegrationTest {
         Files.writeString(path, content + "\n");
     }
 
-    private void dockerBuildAndRunTestingScript(String baseImage, String shell, boolean installCurl)
+    private void dockerBuildAndRunTestingScript(
+            String baseImage, String shell, boolean installCurl, Optional<Path> mountGradleJdkDir)
             throws IOException, InterruptedException {
         Path dockerFile = Path.of("src/integrationTest/resources/template.Dockerfile");
         String dockerImage = String.format("jdk-test-%s", baseImage);
@@ -171,8 +181,12 @@ public class GradleJdkInstallationSetupIntegrationTest {
                 "-f",
                 dockerFile.toAbsolutePath().toString(),
                 workingDir.toAbsolutePath().toString()));
-        assertThat(runCommandWithZeroExitCode(
-                        List.of("docker", "run", "--rm", dockerImage, shell, "/testing-script.sh")))
+
+        ImmutableList.Builder runCommand = ImmutableList.builder().add("docker", "run");
+        mountGradleJdkDir.ifPresent(dir -> runCommand.add(
+                "-v", String.format("%s:/root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1", dir.toAbsolutePath())));
+        runCommand.add("--rm", dockerImage, shell, "/testing-script.sh");
+        assertThat(runCommandWithZeroExitCode(runCommand.build()))
                 .contains("openjdk version \"11.0.21\"")
                 .contains("JAVA_HOME is set to: /root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1");
     }

--- a/gradle-jdks-setup/src/integrationTest/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupIntegrationTest.java
+++ b/gradle-jdks-setup/src/integrationTest/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetupIntegrationTest.java
@@ -174,7 +174,7 @@ public class GradleJdkInstallationSetupIntegrationTest {
                 "--build-arg",
                 String.format("SCRIPT_SHELL=%s", shell),
                 "--build-arg",
-                String.format("INSTALL_CURL=%s", addEmptyGradleJdkDir),
+                String.format("EMPTY_GRADLE_JDK_DIR=%s", addEmptyGradleJdkDir),
                 "-t",
                 dockerImage,
                 "-f",

--- a/gradle-jdks-setup/src/integrationTest/resources/template.Dockerfile
+++ b/gradle-jdks-setup/src/integrationTest/resources/template.Dockerfile
@@ -2,11 +2,15 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 ARG SCRIPT_SHELL
 ENV SCRIPT_SHELL $SCRIPT_SHELL
+ARG EMPTY_GRADLE_JDK_DIR=false
 ARG INSTALL_CURL=false
 # Update package lists and conditionally install curl
 RUN if [ "$INSTALL_CURL" = "true" ] ; then \
         apt-get update && \
         apt-get install -y curl; \
-    fi
+    fi \
+RUN if [ "$EMPTY_GRADLE_JDK_DIR" = "true" ] ; then \
+    mkdir -p "/root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1" \
+    fi \
 COPY . /
 RUN $SCRIPT_SHELL /gradle/gradle-jdks-setup.sh

--- a/gradle-jdks-setup/src/integrationTest/resources/template.Dockerfile
+++ b/gradle-jdks-setup/src/integrationTest/resources/template.Dockerfile
@@ -2,14 +2,14 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 ARG SCRIPT_SHELL
 ENV SCRIPT_SHELL $SCRIPT_SHELL
-ARG EMPTY_GRADLE_JDK_DIR=false
+ARG ADD_JDK_DIR=false
 ARG INSTALL_CURL=false
 # Update package lists and conditionally install curl
 RUN if [ "$INSTALL_CURL" = "true" ] ; then \
         apt-get update && \
         apt-get install -y curl; \
     fi
-RUN if [ "$EMPTY_GRADLE_JDK_DIR" = "true" ] ; then \
+RUN if [ "$ADD_JDK_DIR" = "true" ] ; then \
     mkdir -p "/root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1"; \
     fi
 COPY . /

--- a/gradle-jdks-setup/src/integrationTest/resources/template.Dockerfile
+++ b/gradle-jdks-setup/src/integrationTest/resources/template.Dockerfile
@@ -10,7 +10,7 @@ RUN if [ "$INSTALL_CURL" = "true" ] ; then \
         apt-get install -y curl; \
     fi
 RUN if [ "$EMPTY_GRADLE_JDK_DIR" = "true" ] ; then \
-    mkdir -p "/root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1" \
+    mkdir -p "/root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1"; \
     fi
 COPY . /
 RUN $SCRIPT_SHELL /gradle/gradle-jdks-setup.sh

--- a/gradle-jdks-setup/src/integrationTest/resources/template.Dockerfile
+++ b/gradle-jdks-setup/src/integrationTest/resources/template.Dockerfile
@@ -8,9 +8,9 @@ ARG INSTALL_CURL=false
 RUN if [ "$INSTALL_CURL" = "true" ] ; then \
         apt-get update && \
         apt-get install -y curl; \
-    fi \
+    fi
 RUN if [ "$EMPTY_GRADLE_JDK_DIR" = "true" ] ; then \
     mkdir -p "/root/.gradle/gradle-jdks/amazon-corretto-11.0.21.9.1" \
-    fi \
+    fi
 COPY . /
 RUN $SCRIPT_SHELL /gradle/gradle-jdks-setup.sh

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/FileUtils.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/FileUtils.java
@@ -71,7 +71,7 @@ public final class FileUtils {
 
             @Override
             public FileVisitResult visitFileFailed(Path _file, IOException exc) throws IOException {
-                throw new RuntimeException("Failed to copy file", exc);
+                throw new IOException("Failed to copy file", exc);
             }
 
             @Override

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/FileUtils.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/FileUtils.java
@@ -21,6 +21,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Comparator;
 import java.util.Optional;
@@ -65,7 +66,7 @@ public final class FileUtils {
 
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes _attrs) throws IOException {
-                Files.copy(file, destination.resolve(source.relativize(file)));
+                Files.copy(file, destination.resolve(source.relativize(file)), StandardCopyOption.REPLACE_EXISTING);
                 return FileVisitResult.CONTINUE;
             }
 

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
@@ -20,8 +20,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Properties;
 
@@ -122,14 +124,24 @@ public final class GradleJdkInstallationSetup {
             channel.lock();
             // double-check, now that we hold the lock
             if (Files.exists(destinationJdkInstallationDirectory)
-                    && isJdkInstallationValid(destinationJdkInstallationDirectory)) {
+                    && Files.exists(destinationJdkInstallationDirectory.resolve("bin/java"))) {
                 logger.log(String.format("Distribution URL %s already exists", destinationJdkInstallationDirectory));
                 return false;
             }
             logger.log(
                     String.format("Copying JDK from %s into %s", currentJavaHome, destinationJdkInstallationDirectory));
-            FileUtils.copyDirectory(currentJavaHome, destinationJdkInstallationDirectory);
-            createSentinelFile(destinationJdkInstallationDirectory);
+            Path tempDirWithPrefix = Files.createTempDirectory("gradle-jdks");
+            FileUtils.copyDirectory(currentJavaHome, tempDirWithPrefix);
+            try {
+                Files.move(
+                        tempDirWithPrefix,
+                        destinationJdkInstallationDirectory,
+                        StandardCopyOption.REPLACE_EXISTING,
+                        StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                logger.log("Cannot move the directory to the final directory, attempting to do a non-atomic operation");
+                Files.move(tempDirWithPrefix, destinationJdkInstallationDirectory, StandardCopyOption.REPLACE_EXISTING);
+            }
             return true;
         } catch (IOException e) {
             throw new RuntimeException(
@@ -137,23 +149,6 @@ public final class GradleJdkInstallationSetup {
                             "Failed to copy the JDK installation to path= %s", destinationJdkInstallationDirectory),
                     e);
         }
-    }
-
-    // A JDK installation is considered valid if we either have a 'sentinel' file or 'bin/java' exists
-    private static boolean isJdkInstallationValid(Path destinationJdkInstallationDirectory) {
-        return Files.exists(getSantinelPath(destinationJdkInstallationDirectory))
-                || Files.exists(destinationJdkInstallationDirectory.resolve("bin/java"));
-    }
-
-    private static void createSentinelFile(Path destinationJdkInstallationDirectory) throws IOException {
-        Path sentinelPath = getSantinelPath(destinationJdkInstallationDirectory);
-        if (!Files.exists(sentinelPath)) {
-            Files.createFile(sentinelPath);
-        }
-    }
-
-    private static Path getSantinelPath(Path destinationJdkInstallationDirectory) {
-        return destinationJdkInstallationDirectory.resolve(".sentinel");
     }
 
     private GradleJdkInstallationSetup() {}

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
@@ -142,12 +142,20 @@ public final class GradleJdkInstallationSetup {
                 logger.log("Cannot move the directory to the final directory, attempting to do a non-atomic operation");
                 Files.move(tempDirWithPrefix, destinationJdkInstallationDirectory, StandardCopyOption.REPLACE_EXISTING);
             }
+            createSentinelFile(destinationJdkInstallationDirectory);
             return true;
         } catch (IOException e) {
             throw new RuntimeException(
                     String.format(
                             "Failed to copy the JDK installation to path= %s", destinationJdkInstallationDirectory),
                     e);
+        }
+    }
+
+    private static void createSentinelFile(Path destinationJdkInstallationDirectory) throws IOException {
+        Path sentinelPath = destinationJdkInstallationDirectory.resolve(".sentinel");
+        if (!Files.exists(sentinelPath)) {
+            Files.createFile(sentinelPath);
         }
     }
 

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -144,6 +145,8 @@ public final class GradleJdkInstallationSetup {
                         destinationJdkInstallationDirectory,
                         StandardCopyOption.REPLACE_EXISTING,
                         StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(tempCopyDir, destinationJdkInstallationDirectory, StandardCopyOption.REPLACE_EXISTING);
             } finally {
                 FileUtils.delete(tempCopyDir);
             }

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
@@ -121,7 +121,8 @@ public final class GradleJdkInstallationSetup {
                 lockFile, StandardOpenOption.READ, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
             channel.lock();
             // double-check, now that we hold the lock
-            if (Files.exists(destinationJdkInstallationDirectory)) {
+            if (Files.exists(destinationJdkInstallationDirectory)
+                    && Files.exists(destinationJdkInstallationDirectory.resolve("bin/java"))) {
                 logger.log(String.format("Distribution URL %s already exists", destinationJdkInstallationDirectory));
                 return false;
             }

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
@@ -122,17 +122,38 @@ public final class GradleJdkInstallationSetup {
             channel.lock();
             // double-check, now that we hold the lock
             if (Files.exists(destinationJdkInstallationDirectory)
-                    && Files.exists(destinationJdkInstallationDirectory.resolve("bin/java"))) {
+                    && isJdkInstallationValid(destinationJdkInstallationDirectory)) {
                 logger.log(String.format("Distribution URL %s already exists", destinationJdkInstallationDirectory));
                 return false;
             }
             logger.log(
                     String.format("Copying JDK from %s into %s", currentJavaHome, destinationJdkInstallationDirectory));
             FileUtils.copyDirectory(currentJavaHome, destinationJdkInstallationDirectory);
+            createSentinelFile(destinationJdkInstallationDirectory);
             return true;
         } catch (IOException e) {
-            throw new RuntimeException("Unable to acquire locks, won't move the JDK installation directory", e);
+            throw new RuntimeException(
+                    String.format(
+                            "Failed to copy the JDK installation to path= %s", destinationJdkInstallationDirectory),
+                    e);
         }
+    }
+
+    // A JDK installation is considered valid if we either have a 'sentinel' file or 'bin/java' exists
+    private static boolean isJdkInstallationValid(Path destinationJdkInstallationDirectory) {
+        return Files.exists(getSantinelPath(destinationJdkInstallationDirectory))
+                || Files.exists(destinationJdkInstallationDirectory.resolve("bin/java"));
+    }
+
+    private static void createSentinelFile(Path destinationJdkInstallationDirectory) throws IOException {
+        Path sentinelPath = getSantinelPath(destinationJdkInstallationDirectory);
+        if (!Files.exists(sentinelPath)) {
+            Files.createFile(sentinelPath);
+        }
+    }
+
+    private static Path getSantinelPath(Path destinationJdkInstallationDirectory) {
+        return destinationJdkInstallationDirectory.resolve(".sentinel");
     }
 
     private GradleJdkInstallationSetup() {}

--- a/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
+++ b/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java
@@ -20,7 +20,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -130,32 +129,30 @@ public final class GradleJdkInstallationSetup {
             }
             logger.log(
                     String.format("Copying JDK from %s into %s", currentJavaHome, destinationJdkInstallationDirectory));
-            Path tempDirWithPrefix = Files.createTempDirectory("gradle-jdks");
-            FileUtils.copyDirectory(currentJavaHome, tempDirWithPrefix);
+
+            // same filesystem for the temporary diretory as the destinationDirectory to ensure an atomic move
+            Path tempCopyDir = jdksInstallationDirectory.resolve(
+                    String.format("tmp-%s", destinationJdkInstallationDirectory.getFileName()));
+            // Ensuring that the JDK installation directory won't be partially copied.
+            // 1. Copying the currentJavaHome to a temporary directory inside the jdksInstallationDirectory
+            // 2. Atomic move of the temporary directory to the destination directory
             try {
+                Files.createDirectories(tempCopyDir);
+                FileUtils.copyDirectory(currentJavaHome, tempCopyDir);
                 Files.move(
-                        tempDirWithPrefix,
+                        tempCopyDir,
                         destinationJdkInstallationDirectory,
                         StandardCopyOption.REPLACE_EXISTING,
                         StandardCopyOption.ATOMIC_MOVE);
-            } catch (AtomicMoveNotSupportedException e) {
-                logger.log("Cannot move the directory to the final directory, attempting to do a non-atomic operation");
-                Files.move(tempDirWithPrefix, destinationJdkInstallationDirectory, StandardCopyOption.REPLACE_EXISTING);
+            } finally {
+                FileUtils.delete(tempCopyDir);
             }
-            createSentinelFile(destinationJdkInstallationDirectory);
             return true;
         } catch (IOException e) {
             throw new RuntimeException(
                     String.format(
                             "Failed to copy the JDK installation to path= %s", destinationJdkInstallationDirectory),
                     e);
-        }
-    }
-
-    private static void createSentinelFile(Path destinationJdkInstallationDirectory) throws IOException {
-        Path sentinelPath = destinationJdkInstallationDirectory.resolve(".sentinel");
-        if (!Files.exists(sentinelPath)) {
-            Files.createFile(sentinelPath);
         }
     }
 

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -122,45 +122,50 @@ install_and_setup_jdks() {
     distribution_url=$(read_value "$major_version_dir"/"$OS"/"$ARCH"/download-url)
     # Check if distribution exists in $GRADLE_JDKS_HOME
     jdk_installation_directory="$GRADLE_JDKS_HOME"/"$distribution_local_path"
-    if [ ! -d "$jdk_installation_directory" ]; then
-      # Download and extract the distribution into a temporary directory
-      echo "JDK installation '$jdk_installation_directory' does not exist, installing '$distribution_url' in progress ..."
-      in_progress_dir="$TMP_WORK_DIR/$distribution_local_path.in-progress"
-      mkdir -p "$in_progress_dir"
-      cd "$in_progress_dir" || die "failed to change dir to $in_progress_dir"
-      if command -v curl > /dev/null 2>&1; then
-        echo "Using curl to download $distribution_url"
-        case "$distribution_url" in
-          *.zip)
-            distribution_name=${distribution_url##*/}
-            curl -C - "$distribution_url" -o "$distribution_name"
-            tar -xzf "$distribution_name"
-            ;;
-          *)
-            curl -C - "$distribution_url" | tar -xzf -
-            ;;
-        esac
-      elif command -v wget > /dev/null 2>&1; then
-        echo "Using wget to download $distribution_url"
-        case "$distribution_url" in
-          *.zip)
-            distribution_name=${distribution_url##*/}
-            wget -c "$distribution_url" -O "$distribution_name"
-            tar -xzf "$distribution_name"
-            ;;
-          *)
-            wget -qO- -c "$distribution_url" | tar -xzf -
-            ;;
-        esac
-      else
-        die "ERROR: Neither curl nor wget are installed, Could not set up JAVA_HOME"
-      fi
-      cd - || exit
-
-      # Finding the java_home
-      java_home=$(get_java_home "$in_progress_dir")
-      "$java_home"/bin/java -cp "$scripts_dir"/gradle-jdks-setup.jar com.palantir.gradle.jdks.setup.GradleJdkInstallationSetup jdkSetup "$jdk_installation_directory" || die "Failed to set up JDK $jdk_installation_directory"
-      echo "Successfully installed JDK distribution in $jdk_installation_directory"
+    if [ ! -f "$jdk_installation_directory/bin/java" ]; then
+      echo "Java executable not found in $jdk_installation_directory/bin/java, re-installing the JDK...."
+    elif [ ! -d "$jdk_installation_directory" ]; then
+       echo "JDK installation '$jdk_installation_directory' does not exist, installing '$distribution_url' in progress ..."
+    else
+      echo "JDK installation $jdk_installation_directory was already configured"
+      continue
     fi
+    # Download and extract the distribution into a temporary directory
+    in_progress_dir="$TMP_WORK_DIR/$distribution_local_path.in-progress"
+    mkdir -p "$in_progress_dir"
+    cd "$in_progress_dir" || die "failed to change dir to $in_progress_dir"
+    if command -v curl > /dev/null 2>&1; then
+      echo "Using curl to download $distribution_url"
+      case "$distribution_url" in
+        *.zip)
+          distribution_name=${distribution_url##*/}
+          curl -C - "$distribution_url" -o "$distribution_name"
+          tar -xzf "$distribution_name"
+          ;;
+        *)
+          curl -C - "$distribution_url" | tar -xzf -
+          ;;
+      esac
+    elif command -v wget > /dev/null 2>&1; then
+      echo "Using wget to download $distribution_url"
+      case "$distribution_url" in
+        *.zip)
+          distribution_name=${distribution_url##*/}
+          wget -c "$distribution_url" -O "$distribution_name"
+          tar -xzf "$distribution_name"
+          ;;
+        *)
+          wget -qO- -c "$distribution_url" | tar -xzf -
+          ;;
+      esac
+    else
+      die "ERROR: Neither curl nor wget are installed, Could not set up JAVA_HOME"
+    fi
+    cd - || exit
+
+    # Finding the java_home
+    java_home=$(get_java_home "$in_progress_dir")
+    "$java_home"/bin/java -cp "$scripts_dir"/gradle-jdks-setup.jar com.palantir.gradle.jdks.setup.GradleJdkInstallationSetup jdkSetup "$jdk_installation_directory" || die "Failed to set up JDK $jdk_installation_directory"
+    echo "Successfully installed JDK distribution in $jdk_installation_directory"
   done
 }

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -143,7 +143,7 @@ install_and_setup_jdks() {
           tar -xzf "$distribution_name"
           ;;
         *)
-          curl -C - "$distribution_url" | tar -xzf -
+          curl -k -C - "$distribution_url" | tar -xzf -
           ;;
       esac
     elif command -v wget > /dev/null 2>&1; then

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -122,10 +122,10 @@ install_and_setup_jdks() {
     distribution_url=$(read_value "$major_version_dir"/"$OS"/"$ARCH"/download-url)
     # Check if distribution exists in $GRADLE_JDKS_HOME
     jdk_installation_directory="$GRADLE_JDKS_HOME"/"$distribution_local_path"
-    if [ ! -f "$jdk_installation_directory/bin/java" ]; then
-      echo "Java executable not found in $jdk_installation_directory/bin/java, re-installing the JDK...."
-    elif [ ! -d "$jdk_installation_directory" ]; then
+    if [ ! -d "$jdk_installation_directory" ]; then
       echo "JDK installation '$jdk_installation_directory' does not exist, installing '$distribution_url' in progress ..."
+    elif [ ! -f "$jdk_installation_directory/bin/java" ]; then
+      echo "Java executable not found in $jdk_installation_directory/bin/java, re-installing the JDK...."
     else
       echo "JDK installation $jdk_installation_directory was already configured"
       continue

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -125,7 +125,7 @@ install_and_setup_jdks() {
     if [ ! -f "$jdk_installation_directory/bin/java" ]; then
       echo "Java executable not found in $jdk_installation_directory/bin/java, re-installing the JDK...."
     elif [ ! -d "$jdk_installation_directory" ]; then
-       echo "JDK installation '$jdk_installation_directory' does not exist, installing '$distribution_url' in progress ..."
+      echo "JDK installation '$jdk_installation_directory' does not exist, installing '$distribution_url' in progress ..."
     else
       echo "JDK installation $jdk_installation_directory was already configured"
       continue


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Context: https://pl.ntr/2p9
We consider that a JDK was successfully installed if the directory exists. 
However, this is not always true. eg. if an exception happens while the JDK is copied over to the destination directory (https://github.com/palantir/gradle-jdks/blob/develop/gradle-jdks-setup/src/main/java/com/palantir/gradle/jdks/setup/GradleJdkInstallationSetup.java#L130). The JDK directory might not contain the `bin/java` executable. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
A JDK directory is considered successfully installed if `bin/java` exists . 
I am also doing a copy to a temporary directory and an atomic move to the destination directory.
A `sentinel` file is added at the end of a successful installation - I think we might want to use this in the future to check if the jdk was successfully installed or not. 

Note: I am not considering for now only the `sentinel` file to be the source of truth because of backwards compatibility (the jdks we installed so far won't have the `sentinel` file).

==COMMIT_MSG==
[Fix] JDK is successfully installed if `bin/java` exists
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

