### PR TITLE
Rename check & setupJdks to disambiguate task shortcuts 

### DIFF
--- a/changelog/@unreleased/pr-453.v2.yml
+++ b/changelog/@unreleased/pr-453.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Rename check & setupJdks to disambiguate task shortcuts
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/453

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java
@@ -116,7 +116,7 @@ public final class ToolchainsPlugin implements Plugin<Project> {
             task.finalizedBy(wrapperPatcherTask);
         });
 
-        TaskProvider<Task> checkJdksLifecycle = rootProject.getTasks().register("checkJdks", Task.class, task -> {
+        TaskProvider<Task> checkJdksLifecycle = rootProject.getTasks().register("checkGradleJdks", Task.class, task -> {
             task.setDescription("Lifecycle task that checks the Gradle JDK configurations.");
             task.setGroup(GRADLE_JDK_GROUP);
             task.dependsOn(checkGradleJdkConfigs, checkWrapperPatcherTask);
@@ -127,7 +127,7 @@ public final class ToolchainsPlugin implements Plugin<Project> {
                 .named(LifecycleBasePlugin.CHECK_TASK_NAME)
                 .configure(check -> check.dependsOn(checkJdksLifecycle));
 
-        rootProject.getTasks().register("setupJdks", SetupJdksTask.class, setupJdksTask -> {
+        rootProject.getTasks().register("setupGradleJdks", SetupJdksTask.class, setupJdksTask -> {
             setupJdksTask.setDescription("Configures the gradle JDK setup.");
             setupJdksTask.setGroup(GRADLE_JDK_GROUP);
             setupJdksTask.getGradlewScript().set(wrapperPatcherTask.get().getPatchedGradlewScript());

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java
@@ -127,7 +127,7 @@ public final class ToolchainsPlugin implements Plugin<Project> {
                 .named(LifecycleBasePlugin.CHECK_TASK_NAME)
                 .configure(check -> check.dependsOn(checkJdksLifecycle));
 
-        rootProject.getTasks().register("setupGradleJdks", SetupJdksTask.class, setupJdksTask -> {
+        rootProject.getTasks().register("setupJdks", SetupJdksTask.class, setupJdksTask -> {
             setupJdksTask.setDescription("Configures the gradle JDK setup.");
             setupJdksTask.setGroup(GRADLE_JDK_GROUP);
             setupJdksTask.getGradlewScript().set(wrapperPatcherTask.get().getPatchedGradlewScript());


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Context: https://pl.ntr/2pc
Users were using `gw cJ` to run the compileJava task. `checkJava` is now matching this shortcut as well.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Change task names to disambiguate used shortcuts 
==COMMIT_MSG==
Rename check & setupJdks to disambiguate task shortcuts 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

