### PR TITLE
Remove noisy output

### DIFF
--- a/changelog/@unreleased/pr-458.v2.yml
+++ b/changelog/@unreleased/pr-458.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove noisy output that "JDK installation X was already configured".
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/458

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -127,7 +127,6 @@ install_and_setup_jdks() {
     elif [ ! -f "$jdk_installation_directory/bin/java" ]; then
       echo "Java executable not found in $jdk_installation_directory/bin/java, re-installing the JDK...."
     else
-      echo "JDK installation $jdk_installation_directory was already configured"
       continue
     fi
     # Download and extract the distribution into a temporary directory

--- a/gradle/gradle-jdks-functions.sh
+++ b/gradle/gradle-jdks-functions.sh
@@ -127,7 +127,6 @@ install_and_setup_jdks() {
     elif [ ! -f "$jdk_installation_directory/bin/java" ]; then
       echo "Java executable not found in $jdk_installation_directory/bin/java, re-installing the JDK...."
     else
-      echo "JDK installation $jdk_installation_directory was already configured"
       continue
     fi
     # Download and extract the distribution into a temporary directory

--- a/gradle/gradle-jdks-functions.sh
+++ b/gradle/gradle-jdks-functions.sh
@@ -127,6 +127,7 @@ install_and_setup_jdks() {
     elif [ ! -f "$jdk_installation_directory/bin/java" ]; then
       echo "Java executable not found in $jdk_installation_directory/bin/java, re-installing the JDK...."
     else
+      echo "JDK installation $jdk_installation_directory was already configured"
       continue
     fi
     # Download and extract the distribution into a temporary directory


### PR DESCRIPTION
This output is emitted on every Gradle build for every JDK.

```
JDK installation /Users/pkoenig/.gradle/gradle-jdks/amazon-corretto-11.0.25.9.1 was already configured
JDK installation /Users/pkoenig/.gradle/gradle-jdks/amazon-corretto-17.0.13.11.1 was already configured
JDK installation /Users/pkoenig/.gradle/gradle-jdks/amazon-corretto-21.0.5.11.1 was already configured
```