### PR TITLE
Add default includeAllJdks option to generateGradleJdkConfigs

### DIFF
--- a/changelog/@unreleased/pr-493.v2.yml
+++ b/changelog/@unreleased/pr-493.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add default includeAllJdks option to generateGradleJdkConfigs
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/493

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
@@ -53,9 +53,6 @@ public abstract class GradleJdksConfigs extends DefaultTask {
     @Input
     public abstract MapProperty<String, String> getCaCerts();
 
-    /**
-     * Option to include a specific java major version when generating/checking the gradle jdk configuration files.
-     */
     @Input
     @Option(
             option = "includeAllJdks",

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
@@ -30,6 +30,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 /**
@@ -52,6 +53,15 @@ public abstract class GradleJdksConfigs extends DefaultTask {
     @Input
     public abstract MapProperty<String, String> getCaCerts();
 
+    /**
+     * Option to include a specific java major version when generating/checking the gradle jdk configuration files.
+     */
+    @Input
+    @Option(
+            option = "includeAllJdks",
+            description = "Generates the configuration directories for all configured Java major versions.")
+    public abstract Property<Boolean> getIncludeAllJdks();
+
     abstract Directory gradleDirectory();
 
     protected abstract void applyGradleJdkFileAction(
@@ -64,6 +74,11 @@ public abstract class GradleJdksConfigs extends DefaultTask {
     protected abstract void applyGradleJdkScriptAction(File gradleJdkScriptFile, String resourceName);
 
     protected abstract void maybePrepareForAction(List<Path> targetPaths);
+
+    public GradleJdksConfigs() {
+        // TODO(crogoz): change to false, once we switch to using jdksExtension's jdkMajorVersionsToUse
+        getIncludeAllJdks().convention(true);
+    }
 
     @TaskAction
     public final void action() {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
In preparation for https://github.com/palantir/gradle-jdks/pull/479/files#diff-53f3309ab573fe65d62f8b5bf40e9bb94478d82b4d6434cb6bcf9b25516813a4R79. That PR will only install & configure only the jdk versions used. Because of this, excavators that bump the java versions (eg. https://pl.ntr/2q1), would need to pre-install extra java versions. For this, I have added the command line option `./gradlew generateGradleJdkConfigs --includeAllJdks` that will generate all the jdk configuration files. 
In this PR, the addition is a noop. It only allows the excavators that update the java versions to use the new command line to ensure they are not broken when https://github.com/palantir/gradle-jdks/pull/479/files is merged. 

==COMMIT_MSG==
Add default includeAllJdks option to generateGradleJdkConfigs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

