### PR TITLE
Remove internal shaded jar import from `ConfigureJdksIdeaPluginXml`

### DIFF
--- a/changelog/@unreleased/pr-499.v2.yml
+++ b/changelog/@unreleased/pr-499.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix a possible project sync error when opening IntelliJ by removing
+    an import to `org.gradle.internal.impldep.com.google.common.collect.ImmutableMap`.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/499

--- a/gradle-jdks-groovy/src/main/groovy/com/palantir/gradle/jdks/ConfigureJdksIdeaPluginXml.groovy
+++ b/gradle-jdks-groovy/src/main/groovy/com/palantir/gradle/jdks/ConfigureJdksIdeaPluginXml.groovy
@@ -18,7 +18,6 @@ package com.palantir.gradle.jdks
 
 import groovy.xml.XmlNodePrinter
 import groovy.xml.XmlParser
-import org.gradle.internal.impldep.com.google.common.collect.ImmutableMap
 import org.xml.sax.SAXException
 
 import javax.xml.parsers.ParserConfigurationException
@@ -39,7 +38,9 @@ class ConfigureJdksIdeaPluginXml {
             if (!createIfAbsent) {
                 return;
             }
-            rootNode = new Node(null, "project", ImmutableMap.of("version", "4"));
+            // Using Map rather than ImmutableMap to avoid a Guava dependency.
+            Map<String, String> projectNodeAttributes = Map.of("version", "4");
+            rootNode = new Node(null, "project", projectNodeAttributes);
         }
 
         configureExternalDependencies(rootNode, minVersion)


### PR DESCRIPTION
## Problem

When opening a private project in IntelliJ, we're seeing a strange import error during the Gradle project sync phase.

```
Unable to load class 'org.gradle.internal.impldep.com.google.common.collect.ImmutableMap'.

This is an unexpected error. Please file a bug containing the idea.log file.
```

Here's the condensed stacktrace.

```
* Exception is:
org.gradle.internal.event.ListenerNotificationException: Failed to notify build listener.
	at org.gradle.internal.event.AbstractBroadcastDispatch.dispatch(AbstractBroadcastDispatch.java:112)
Caused by: java.lang.NoClassDefFoundError: org/gradle/internal/impldep/com/google/common/collect/ImmutableMap
	at com.palantir.gradle.jdks.ConfigureJdksIdeaPluginXml.updateIdeaXmlFile(ConfigureJdksIdeaPluginXml.groovy:42)
Caused by: java.lang.ClassNotFoundException: org.gradle.internal.impldep.com.google.common.collect.ImmutableMap
	... 170 more
```

## Theory

It looks like this plugin imports `ImmutableMap` from an [internal shaded jar in Gradle](https://github.com/gradle/gradle/blob/b6e0160a79046236466eb4c8f3f5ae836d3902a8/build-logic/packaging/src/main/kotlin/gradlebuild.shaded-jar.gradle.kts#L57). I suspect this import was accidental.

It's also possible the import as written was intentional, and the private repo I'm working on is doing something it's not supposed to with its `settings.gradle`. 😅

If we think that's the case, I'm happy to close this PR.