### PR TITLE
update error message to redirect to internal docs for cases where all `gradle-sls-docker` plugins have been removed

### DIFF
--- a/changelog/@unreleased/pr-507.v2.yml
+++ b/changelog/@unreleased/pr-507.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: update error message
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/507

--- a/changelog/@unreleased/pr-507.v2.yml
+++ b/changelog/@unreleased/pr-507.v2.yml
@@ -1,5 +1,6 @@
 type: fix
 fix:
-  description: update error message
+  description: update error message to redirect to internal docs for cases where all
+    gradle-sls-docker plugins have been removed
   links:
   - https://github.com/palantir/gradle-jdks/pull/507

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
@@ -98,7 +98,7 @@ public abstract class GradleJdksConfigs extends DefaultTask {
                             + " JDKs and ensure that you have configured JDKs properly for gradle-jdks as per"
                             + " the readme: https://github.com/palantir/gradle-jdks#usage."
                             + " Palantirians: If you see this error on an internal project after removing all"
-                            + " gradle-sls-docker related plugins, see https://pl.ntr/2v1 to fix.");
+                            + " `gradle-sls-docker` related plugins, see https://pl.ntr/2v1 to fix.");
         }
 
         String gradleJdkDaemonVersion = getDaemonJavaVersion().get().toString();

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
@@ -96,7 +96,9 @@ public abstract class GradleJdksConfigs extends DefaultTask {
             throw new RuntimeException(
                     "No JDKs were configured for the gradle setup. Please run `./gradlew setupJdks` to generate the"
                             + " JDKs and ensure that you have configured JDKs properly for gradle-jdks as per"
-                            + " the readme: https://github.com/palantir/gradle-jdks#usage");
+                            + " the readme: https://github.com/palantir/gradle-jdks#usage"
+                            + " if you see this error after removing all `gradle-sls-docker` plugins"
+                            + " see: https://pl.ntr/2v1");
         }
 
         String gradleJdkDaemonVersion = getDaemonJavaVersion().get().toString();

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
@@ -96,9 +96,9 @@ public abstract class GradleJdksConfigs extends DefaultTask {
             throw new RuntimeException(
                     "No JDKs were configured for the gradle setup. Please run `./gradlew setupJdks` to generate the"
                             + " JDKs and ensure that you have configured JDKs properly for gradle-jdks as per"
-                            + " the readme: https://github.com/palantir/gradle-jdks#usage"
-                            + " if you see this error after removing all `gradle-sls-docker` plugins"
-                            + " see: https://pl.ntr/2v1");
+                            + " the readme: https://github.com/palantir/gradle-jdks#usage."
+                            + " Palantirians: If you see this error on an internal project after removing all"
+                            + " gradle-sls-docker related plugins, see https://pl.ntr/2v1 to fix.");
         }
 
         String gradleJdkDaemonVersion = getDaemonJavaVersion().get().toString();


### PR DESCRIPTION
## Before this PR
Did not link to correct docs for cases where all gradle-sls-docker plugins have been
## After this PR
Now links to docs directly in error message
==COMMIT_MSG==
update error message to redirect to internal docs for cases where all `gradle-sls-docker` plugins have been removed
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

