### PR TITLE
Disable Gradle JDK Automanagement workflow when running on mingw

### DIFF
--- a/changelog/@unreleased/pr-534.v2.yml
+++ b/changelog/@unreleased/pr-534.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: '[Gradle JDK Enablement] Mingw is not supported'
+  description: Disable Gradle JDK Automanagement workflow when running on mingw
   links:
   - https://github.com/palantir/gradle-jdks/pull/534

--- a/changelog/@unreleased/pr-534.v2.yml
+++ b/changelog/@unreleased/pr-534.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[Gradle JDK Enablement] Mingw is not supported'
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/534

--- a/gradle-jdks-setup-common/src/main/java/com/palantir/gradle/jdks/setup/common/CurrentOs.java
+++ b/gradle-jdks-setup-common/src/main/java/com/palantir/gradle/jdks/setup/common/CurrentOs.java
@@ -31,7 +31,7 @@ public final class CurrentOs {
             return Os.MACOS;
         }
 
-        if (osName.startsWith("windows")) {
+        if (osName.startsWith("windows") || osName.startsWith("mingw")) {
             return Os.WINDOWS;
         }
 

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -49,12 +49,11 @@ read_value() {
 }
 
 get_os() {
-  os_name = "unsupported"
   # OS specific support; same as gradle-jdks:com.palantir.gradle.jdks.setup.common.CurrentOs.java
   case "$( uname )" in                          #(
     Linux* )          os_name="linux"  ;;       #(
     Darwin* )         os_name="macos"  ;;       #(
-    * )               echo "ERROR Unsupported OS: $( uname )" ;;
+    * )               os_name = "unsupported" && echo "ERROR Unsupported OS: $( uname )" ;;
   esac
 
   if [ "$os_name" = "linux" ]; then
@@ -74,7 +73,6 @@ get_os() {
 }
 
 get_arch() {
-  arch_name = "unsupported"
   # Arch specific support, see: gradle-jdks:com.palantir.gradle.jdks.setup.common.CurrentArch.java
   case "$(uname -m)" in                         #(
     x86_64* )       arch_name="x86-64"  ;;      #(
@@ -85,7 +83,7 @@ get_arch() {
     aarch64* )      arch_name="aarch64"  ;;     #(
     x86* )          arch_name="x86"  ;;         #(
     i686* )         arch_name="x86"  ;;         #(
-    * )             echo "Unsupported architecture: $( uname -m )" ;;
+    * )             arch_name = "unsupported" && echo "Unsupported architecture: $( uname -m )" ;;
   esac
 
   echo "$arch_name"
@@ -113,7 +111,7 @@ ARCH=$(get_arch)
 export ARCH
 
 is_arch_os_supported() {
-  if [ "$OS" = "unsupported" || "$ARCH" = "unsupported"]; then
+  if [ "$OS" = "unsupported" ] || [ "$ARCH" = "unsupported" ]; then
     echo false
   fi
   echo true

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -49,7 +49,7 @@ read_value() {
 }
 
 get_os() {
-  local os_name = "unsupported"
+  os_name = "unsupported"
   # OS specific support; same as gradle-jdks:com.palantir.gradle.jdks.setup.common.CurrentOs.java
   case "$( uname )" in                          #(
     Linux* )          os_name="linux"  ;;       #(
@@ -74,7 +74,7 @@ get_os() {
 }
 
 get_arch() {
-  local arch_name = "unsupported"
+  arch_name = "unsupported"
   # Arch specific support, see: gradle-jdks:com.palantir.gradle.jdks.setup.common.CurrentArch.java
   case "$(uname -m)" in                         #(
     x86_64* )       arch_name="x86-64"  ;;      #(

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -53,7 +53,7 @@ get_os() {
   case "$( uname )" in                          #(
     Linux* )          os_name="linux"  ;;       #(
     Darwin* )         os_name="macos"  ;;       #(
-    * )               os_name = "unsupported" && echo "ERROR Unsupported OS: $( uname )" ;;
+    * )               os_name="unsupported";;
   esac
 
   if [ "$os_name" = "linux" ]; then
@@ -83,7 +83,7 @@ get_arch() {
     aarch64* )      arch_name="aarch64"  ;;     #(
     x86* )          arch_name="x86"  ;;         #(
     i686* )         arch_name="x86"  ;;         #(
-    * )             arch_name = "unsupported" && echo "Unsupported architecture: $( uname -m )" ;;
+    * )             arch_name="unsupported";;
   esac
 
   echo "$arch_name"

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -121,12 +121,6 @@ install_and_setup_jdks() {
   gradle_dir=$1
   scripts_dir=${2:-"$1"}
 
-  supported=$(is_arch_os_supported)
-  if [ ! supported ]; then
-    echo "OS/Arch not supported, Skipping Gradle JDK Automanagemnt Setup..."
-    return
-  fi
-
   for dir in "$gradle_dir"/jdks/*/; do
     major_version_dir=${dir%*/}
     major_version=${major_version_dir##*/}

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -49,11 +49,12 @@ read_value() {
 }
 
 get_os() {
+  local os_name = "unsupported"
   # OS specific support; same as gradle-jdks:com.palantir.gradle.jdks.setup.common.CurrentOs.java
   case "$( uname )" in                          #(
     Linux* )          os_name="linux"  ;;       #(
     Darwin* )         os_name="macos"  ;;       #(
-    * )               die "ERROR Unsupported OS: $( uname )" ;;
+    * )               echo "ERROR Unsupported OS: $( uname )" ;;
   esac
 
   if [ "$os_name" = "linux" ]; then
@@ -73,6 +74,7 @@ get_os() {
 }
 
 get_arch() {
+  local arch_name = "unsupported"
   # Arch specific support, see: gradle-jdks:com.palantir.gradle.jdks.setup.common.CurrentArch.java
   case "$(uname -m)" in                         #(
     x86_64* )       arch_name="x86-64"  ;;      #(
@@ -83,7 +85,7 @@ get_arch() {
     aarch64* )      arch_name="aarch64"  ;;     #(
     x86* )          arch_name="x86"  ;;         #(
     i686* )         arch_name="x86"  ;;         #(
-    * )             die "ERROR Unsupported architecture: $( uname -m )" ;;
+    * )             echo "Unsupported architecture: $( uname -m )" ;;
   esac
 
   echo "$arch_name"
@@ -110,9 +112,22 @@ export OS
 ARCH=$(get_arch)
 export ARCH
 
+is_arch_os_supported() {
+  if [ "$OS" = "unsupported" || "$ARCH" = "unsupported"]; then
+    echo false
+  fi
+  echo true
+}
+
 install_and_setup_jdks() {
   gradle_dir=$1
   scripts_dir=${2:-"$1"}
+
+  supported=$(is_arch_os_supported)
+  if [ ! supported ]; then
+    echo "OS/Arch not supported, Skipping Gradle JDK Automanagemnt Setup..."
+    return
+  fi
 
   for dir in "$gradle_dir"/jdks/*/; do
     major_version_dir=${dir%*/}

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-setup.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-setup.sh
@@ -67,7 +67,7 @@ APP_GRADLE_DIR="$APP_HOME"/gradle
 # Loading gradle jdk functions
 . "$APP_GRADLE_DIR"/gradle-jdks-functions.sh
 
-if [ ! $(is_arch_os_supported) ]; then
+if ! $(is_arch_os_supported); then
   echo "Skipping Gradle JDKs Setup, Unsupported OS/Arch..."
   cleanup
   return

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-setup.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-setup.sh
@@ -67,6 +67,12 @@ APP_GRADLE_DIR="$APP_HOME"/gradle
 # Loading gradle jdk functions
 . "$APP_GRADLE_DIR"/gradle-jdks-functions.sh
 
+if [ ! $(is_arch_os_supported) ]; then
+  echo "Skipping Gradle JDKs Setup, Unsupported OS/Arch..."
+  cleanup
+  return
+fi
+
 install_and_setup_jdks "$APP_GRADLE_DIR"
 
 gradle_daemon_jdk_version=$(read_value "$APP_GRADLE_DIR"/gradle-daemon-jdk-version)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Failing when using mingw shell: https://pl.ntr/2tn
```
ERROR Unsupported OS: MINGW64_NT-10.0-17763

ERROR: /c/Users/circleci/project/gradle/jdks/11//x86-64/local-path not found, aborting Gradle JDK setup

ERROR: /c/Users/circleci/project/gradle/jdks/11//x86-64/download-url not found, aborting Gradle JDK setup
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Mingw is unsupported, Gradle JDK Automanagement will not be set up.
Tested successfully: https://pl.ntr/2to

==COMMIT_MSG==
[Gradle JDK Enablement] Mingw is not supported
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

