### PR TITLE
[Gradle JDKs setup] Fix scripts when OS/Arch is not supported 

### DIFF
--- a/changelog/@unreleased/pr-551.v2.yml
+++ b/changelog/@unreleased/pr-551.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[Gradle JDKs setup] Fix scripts when OS/Arch is not supported'
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/551

--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-setup.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-setup.sh
@@ -69,18 +69,17 @@ APP_GRADLE_DIR="$APP_HOME"/gradle
 
 if ! is_arch_os_supported; then
   echo "Skipping Gradle JDKs Setup, Unsupported OS/Arch..."
-  cleanup
-  return
+else
+  install_and_setup_jdks "$APP_GRADLE_DIR"
+
+  gradle_daemon_jdk_version=$(read_value "$APP_GRADLE_DIR"/gradle-daemon-jdk-version)
+  gradle_daemon_jdk_distribution_local_path=$(read_value "$APP_GRADLE_DIR"/jdks/"$gradle_daemon_jdk_version"/"$OS"/"$ARCH"/local-path)
+  "$GRADLE_JDKS_HOME"/"$gradle_daemon_jdk_distribution_local_path"/bin/java -cp "$APP_GRADLE_DIR"/gradle-jdks-setup.jar com.palantir.gradle.jdks.setup.GradleJdkInstallationSetup daemonSetup "$APP_HOME" "$GRADLE_JDKS_HOME/$gradle_daemon_jdk_distribution_local_path"
+
+  # [Used by ./gradlew only] Setting the Gradle Daemon Java Home to the JDK distribution
+  export GRADLE_DAEMON_JDK="$GRADLE_JDKS_HOME/$gradle_daemon_jdk_distribution_local_path"
+  set -- "-Dorg.gradle.java.home=$GRADLE_DAEMON_JDK" "$@"
+
 fi
-
-install_and_setup_jdks "$APP_GRADLE_DIR"
-
-gradle_daemon_jdk_version=$(read_value "$APP_GRADLE_DIR"/gradle-daemon-jdk-version)
-gradle_daemon_jdk_distribution_local_path=$(read_value "$APP_GRADLE_DIR"/jdks/"$gradle_daemon_jdk_version"/"$OS"/"$ARCH"/local-path)
-"$GRADLE_JDKS_HOME"/"$gradle_daemon_jdk_distribution_local_path"/bin/java -cp "$APP_GRADLE_DIR"/gradle-jdks-setup.jar com.palantir.gradle.jdks.setup.GradleJdkInstallationSetup daemonSetup "$APP_HOME" "$GRADLE_JDKS_HOME/$gradle_daemon_jdk_distribution_local_path"
-
-# [Used by ./gradlew only] Setting the Gradle Daemon Java Home to the JDK distribution
-export GRADLE_DAEMON_JDK="$GRADLE_JDKS_HOME/$gradle_daemon_jdk_distribution_local_path"
-set -- "-Dorg.gradle.java.home=$GRADLE_DAEMON_JDK" "$@"
 
 cleanup


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Fixing `./gradle/gradle-jdks-setup.sh: line 73: return: can only `return' from a function or sourced script`

Follow-up for https://github.com/palantir/gradle-jdks/pull/549. 


==COMMIT_MSG==
[Gradle JDKs setup] Fix scripts when OS/Arch is not supported 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

