### PR TITLE
Add support for Eclipse Temurin JDKs

### DIFF
--- a/changelog/@unreleased/pr-554.v2.yml
+++ b/changelog/@unreleased/pr-554.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add support for Eclipse Temurin JDKs
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/554

--- a/gradle-jdks-distributions/src/main/java/com/palantir/gradle/jdks/JdkDistributionName.java
+++ b/gradle-jdks-distributions/src/main/java/com/palantir/gradle/jdks/JdkDistributionName.java
@@ -24,7 +24,8 @@ import java.util.Optional;
 public enum JdkDistributionName {
     AZUL_ZULU,
     AMAZON_CORRETTO,
-    GRAALVM_CE;
+    GRAALVM_CE,
+    ECLIPSE_TEMURIN;
 
     JdkDistributionName() {}
 

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/EclipseTemurinJdkDistribution.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/EclipseTemurinJdkDistribution.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+import com.palantir.gradle.jdks.JdkPath.Extension;
+import com.palantir.gradle.jdks.setup.common.Arch;
+import com.palantir.gradle.jdks.setup.common.Os;
+
+public final class EclipseTemurinJdkDistribution implements JdkDistribution {
+    @Override
+    public String defaultBaseUrl() {
+        return "https://github.com/adoptium";
+    }
+
+    @Override
+    public JdkPath path(JdkRelease jdkRelease) {
+        String filename = String.format(
+                "temurin%s-binaries/releases/download/jdk-%s/OpenJDK%sU-jdk_%s_%s_hotspot_%s",
+                majorVersion(jdkRelease.version()),
+                jdkRelease.version(),
+                majorVersion(jdkRelease.version()),
+                arch(jdkRelease.arch()),
+                os(jdkRelease.os()),
+                jdkRelease.version().replace('+', '_'));
+
+        return JdkPath.builder()
+                .filename(filename)
+                .extension(extension(jdkRelease.os()))
+                .build();
+    }
+
+    private static String os(Os os) {
+        switch (os) {
+            case MACOS:
+                return "mac";
+            case LINUX_GLIBC:
+                return "linux";
+            case LINUX_MUSL:
+                return "alpine-linux";
+            case WINDOWS:
+                return "windows";
+        }
+
+        throw new UnsupportedOperationException("Case " + os + " not implemented");
+    }
+
+    private static Extension extension(Os os) {
+        switch (os) {
+            case MACOS:
+            case LINUX_GLIBC:
+            case LINUX_MUSL:
+                return Extension.TARGZ;
+            case WINDOWS:
+                return Extension.ZIP;
+        }
+
+        throw new UnsupportedOperationException("Case " + os + " not implemented");
+    }
+
+    private static String arch(Arch arch) {
+        switch (arch) {
+            case X86_64:
+                return "x64";
+            case AARCH64:
+                return "aarch64";
+        }
+
+        throw new UnsupportedOperationException("Case " + arch + " not implemented");
+    }
+
+    private static String majorVersion(String version) {
+        String[] parts = version.split("\\.");
+
+        if (parts.length > 0) {
+            return parts[0];
+        } else {
+            throw new UnsupportedOperationException("Major Version not found in " + version);
+        }
+    }
+}

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkDistributions.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkDistributions.java
@@ -26,7 +26,9 @@ final class JdkDistributions {
             JdkDistributionName.AMAZON_CORRETTO,
             new AmazonCorrettoJdkDistribution(),
             JdkDistributionName.GRAALVM_CE,
-            new GraalVmCeDistribution());
+            new GraalVmCeDistribution(),
+            JdkDistributionName.ECLIPSE_TEMURIN,
+            new EclipseTemurinJdkDistribution());
 
     public JdkDistribution get(JdkDistributionName jdkDistributionName) {
         return Optional.ofNullable(JDK_DISTRIBUTIONS.get(jdkDistributionName))

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/EclipseTemurinJdkDistributionTest.java
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/EclipseTemurinJdkDistributionTest.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.gradle.jdks.JdkPath.Extension;
+import com.palantir.gradle.jdks.setup.common.Arch;
+import com.palantir.gradle.jdks.setup.common.Os;
+import org.junit.jupiter.api.Test;
+
+class EclipseTemurinJdkDistributionTest {
+    @Test
+    void jdk_path_musl_linux_x64_64() {
+        EclipseTemurinJdkDistribution distribution = new EclipseTemurinJdkDistribution();
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(Arch.X86_64)
+                .os(Os.LINUX_MUSL)
+                .version("21.0.7+6")
+                .build());
+        assertThat(path.filename())
+                .isEqualTo("temurin21-binaries/releases/download/"
+                        + "jdk-21.0.7+6/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.7_6");
+        assertThat(path.extension()).isEqualTo(Extension.TARGZ);
+    }
+
+    @Test
+    void jdk_path_macosx() {
+        EclipseTemurinJdkDistribution distribution = new EclipseTemurinJdkDistribution();
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(Arch.AARCH64)
+                .os(Os.MACOS)
+                .version("17.0.15+6")
+                .build());
+        assertThat(path.filename())
+                .isEqualTo("temurin17-binaries/releases/download/"
+                        + "jdk-17.0.15+6/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.15_6");
+        assertThat(path.extension()).isEqualTo(Extension.TARGZ);
+    }
+
+    @Test
+    void jdk_path_windows_x86_64() {
+        EclipseTemurinJdkDistribution distribution = new EclipseTemurinJdkDistribution();
+        JdkPath path = distribution.path(JdkRelease.builder()
+                .arch(Arch.X86_64)
+                .os(Os.WINDOWS)
+                .version("11.0.27+6")
+                .build());
+        assertThat(path.filename())
+                .isEqualTo("temurin11-binaries/releases/download/"
+                        + "jdk-11.0.27+6/OpenJDK11U-jdk_x64_windows_hotspot_11.0.27_6");
+        assertThat(path.extension()).isEqualTo(Extension.ZIP);
+    }
+}


### PR DESCRIPTION
## Before this PR
Only Azul Zulu, Amazon Corretto and GraalVM JDKs are supported.

## After this PR
Eclipse Temurin JDKs can be used.

==COMMIT_MSG==
Add support for Eclipse Temurin JDKs
==COMMIT_MSG==

## Possible downsides?


