### PR TITLE
Fix ABI break for `isGradleJdkSetupEnabled` by readding the deleted `isGradleJdkSetupEnabled(Path)` method

### DIFF
--- a/changelog/@unreleased/pr-577.v2.yml
+++ b/changelog/@unreleased/pr-577.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix ABI break for `isGradleJdkSetupEnabled` by readding the deleted
+    `isGradleJdkSetupEnabled(Path)` method
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/577

--- a/gradle-jdks-enablement/src/main/java/com/palantir/gradle/jdks/enablement/GradleJdksEnablement.java
+++ b/gradle-jdks-enablement/src/main/java/com/palantir/gradle/jdks/enablement/GradleJdksEnablement.java
@@ -28,6 +28,10 @@ public final class GradleJdksEnablement {
 
     public static final String MINIMUM_SUPPORTED_GRADLE_VERSION = "7.6";
 
+    public static boolean isGradleJdkSetupEnabled(Path projectDir) {
+        return isGradleJdkSetupEnabled(OperatingSystem.get(), projectDir);
+    }
+
     public static boolean isGradleJdkSetupEnabled(OperatingSystem operatingSystem, Path projectDir) {
         return !operatingSystem.equals(OperatingSystem.WINDOWS) && isGradleJdkPropertyEnabled(projectDir);
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

In https://github.com/palantir/gradle-jdks/pull/575, we added an `OperatingSystem` parameter to `isGradleJdkSetupEnabled`, forgetting that it is a public library method being [used in other repositories](https://github.com/palantir/gradle-jdks-latest/blob/f94a936b8038d7a30684d112a775be9535057f28/gradle-jdks-latest/src/main/java/com/palantir/gradle/jdkslatest/LatestJdksPlugin.java#L35)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->


==COMMIT_MSG==
Fix ABI break for `isGradleJdkSetupEnabled` by readding the deleted `isGradleJdkSetupEnabled(Path)` method
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

