### PR TITLE
Use `javaVersions.allJavaVersionsUsed` where available instead of deeply reaching into baseline-java-versions

### DIFF
--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java
@@ -25,11 +25,15 @@ import com.palantir.gradle.jdks.GradleWrapperPatcher.GradleWrapperPatcherTask;
 import com.palantir.gradle.jdks.enablement.GradleJdksEnablement;
 import com.palantir.gradle.jdks.flow.ToolchainFailureFlowActionsPlugin;
 import com.palantir.platform.GradleOperatingSystem;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.wrapper.Wrapper;
@@ -78,23 +82,28 @@ public abstract class ToolchainsPlugin implements Plugin<Project> {
         rootProject.getPluginManager().withPlugin("com.palantir.baseline-java-versions", unused -> {
             BaselineJavaVersionsExtension baselineJavaVersionsExtension =
                     rootProject.getExtensions().getByType(BaselineJavaVersionsExtension.class);
-            baselineJavaVersionsExtension.getSetupJdkToolchains().set(false);
 
+            baselineJavaVersionsExtension.getSetupJdkToolchains().set(false);
             jdksExtension.jdkMajorVersionsToUse().add(jdksExtension.getDaemonTarget());
-            jdksExtension.jdkMajorVersionsToUse().add(baselineJavaVersionsExtension.libraryTarget());
-            jdksExtension.jdkMajorVersionsToUse().add(asJavaLanguageVersion(baselineJavaVersionsExtension.runtime()));
-            jdksExtension
-                    .jdkMajorVersionsToUse()
-                    .add(asJavaLanguageVersion(baselineJavaVersionsExtension.distributionTarget()));
+
+            try {
+                // We use reflection here to avoid having to bump baseline to latest to get this out.
+                // This is because there are quite a few stragglers and I'd rather not delay using this.
+                // Once enough time has passed and baseline is generally high enough, we should just bump
+                // the baseline dep and use the code directly.
+                Method allJavaVersionsUsed =
+                        BaselineJavaVersionsExtension.class.getDeclaredMethod("allJavaVersionsUsed");
+                jdksExtension.jdkMajorVersionsToUse().addAll((Provider<Set<JavaLanguageVersion>>)
+                        allJavaVersionsUsed.invoke(baselineJavaVersionsExtension));
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(
+                        "Failed to invoke BaselineJavaVersionsExtension#allJavaVersionsUsed despite it existing", e);
+            } catch (NoSuchMethodException e) {
+                gatherAllMajorVersionsUsedFromBaselineJavaVersions(
+                        rootProject, jdksExtension.jdkMajorVersionsToUse(), baselineJavaVersionsExtension);
+            }
         });
 
-        rootProject.subprojects(
-                proj -> proj.getPluginManager().withPlugin("com.palantir.baseline-java-version", unused -> {
-                    BaselineJavaVersionExtension projectVersions =
-                            proj.getExtensions().getByType(BaselineJavaVersionExtension.class);
-                    jdksExtension.jdkMajorVersionsToUse().add(asJavaLanguageVersion(projectVersions.target()));
-                    jdksExtension.jdkMajorVersionsToUse().add(asJavaLanguageVersion(projectVersions.runtime()));
-                }));
         TaskProvider<Wrapper> wrapperTask = rootProject.getTasks().named("wrapper", Wrapper.class);
 
         TaskProvider<GenerateGradleJdksConfigsTask> generateGradleJdkConfigs = rootProject
@@ -172,6 +181,24 @@ public abstract class ToolchainsPlugin implements Plugin<Project> {
         rootProject.getTasks().named("javaToolchains").configure(task -> {
             task.mustRunAfter(checkJdksLifecycle);
         });
+    }
+
+    private void gatherAllMajorVersionsUsedFromBaselineJavaVersions(
+            Project rootProject,
+            SetProperty<JavaLanguageVersion> jdkMajorVersionsToUse,
+            BaselineJavaVersionsExtension baselineJavaVersionsExtension) {
+
+        jdkMajorVersionsToUse.add(baselineJavaVersionsExtension.libraryTarget());
+        jdkMajorVersionsToUse.add(asJavaLanguageVersion(baselineJavaVersionsExtension.runtime()));
+        jdkMajorVersionsToUse.add(asJavaLanguageVersion(baselineJavaVersionsExtension.distributionTarget()));
+
+        rootProject.subprojects(
+                proj -> proj.getPluginManager().withPlugin("com.palantir.baseline-java-version", unused -> {
+                    BaselineJavaVersionExtension projectVersions =
+                            proj.getExtensions().getByType(BaselineJavaVersionExtension.class);
+                    jdkMajorVersionsToUse.add(asJavaLanguageVersion(projectVersions.target()));
+                    jdkMajorVersionsToUse.add(asJavaLanguageVersion(projectVersions.runtime()));
+                }));
     }
 
     private static boolean isGradleVersionSupported() {


### PR DESCRIPTION
## Before this PR
See the related baseline-java-versions PR: https://github.com/palantir/gradle-baseline/pull/3399

`gradle-jdks` needs to know what JDKs are being used in a build to work out which JDKs it should actually set up. It currently does this by [deeply inspecting all the values inside the `javaVersions` and `javaVersion` extensions](https://github.com/palantir/gradle-jdks/blob/19d1f68fc8b933df9536d00b5d1641ade134a830/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java#L83-L97).

This is problematic, as [I'm about to add a `javaCompiler` option to `javaVersions`](https://github.com/palantir/gradle-baseline/pull/3342) it will need to know about. Currently, `gradle-jdks` is tightly coupled as it needs to know the internal structure of `baseline-java-versions`. When we come to add `javaCompiler`, if we set it to a JDK not already in used in a project (eg `javaCompiler = 25`) then `gradle-jdks` will not know to install it without it's own logic being updated.

If the structure of `baseline-java-versions` ever changes again, `gradle-jdks` will need updating, which is grim.

## After this PR
==COMMIT_MSG==
Use `javaVersions.allJavaVersionsUsed` where available instead of deeply reaching into baseline-java-versions
==COMMIT_MSG==

`gradle-jdks` now uses this method instead and avoid the tight coupling. When we add `javaCompiler`, it will get the new JDK automatically with no code changes.

## Possible downsides?
I've opted to implement this using reflection to see if the method is available, and if not falling back to the previous implementation. This is just so I can avoid bumping this plugin's baseline dependency to latest, which would block a lot of gradle-jdks upgrade PRs as there are repos that are stuck upgrading baseline at the moment. I'm also about to do a breaking baseline change, so want to reduce the scope of dependency upgrade problems for now.

Unfortunately, I can't test against the newer gradle-baseline without bumping the gradle-baseline dep. Or test against both the old and new codepath at the same time. So it's only testing against the old codepath. I have tested manually that the new codepath works though. When we bump the baseline dep, the new codepath will be tested/the old codepath will be removed.

