### PR TITLE
Prepare for GradlePluginTests integration

### DIFF
--- a/gradle-jdks/build.gradle
+++ b/gradle-jdks/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.ow2.asm:asm'
     implementation 'com.palantir.gradle.idea-configuration:gradle-idea-configuration'
     implementation 'com.palantir.gradle.utils:platform'
+    implementation 'com.palantir.gradle.utils:environment-variables'
 
     compileOnly 'org.immutables:value::annotations'
     annotationProcessor 'org.immutables:value'

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigs.java
@@ -67,12 +67,6 @@ public abstract class GradleJdksConfigs extends DefaultTask {
     }
 
     @Input
-    @Option(
-            option = "onlyForCurrentOsArch",
-            description = "Generates the configuration directories only for the current Os & Arch.")
-    public abstract Property<Boolean> getIncludeOnlyCurrentOsArch();
-
-    @Input
     public abstract ListProperty<String> getIncludeJavaMajorVersions();
 
     @Nested
@@ -99,7 +93,6 @@ public abstract class GradleJdksConfigs extends DefaultTask {
 
     public GradleJdksConfigs() {
         getIncludeAllJdks().convention(false);
-        getIncludeOnlyCurrentOsArch().convention(false);
     }
 
     @TaskAction
@@ -121,18 +114,14 @@ public abstract class GradleJdksConfigs extends DefaultTask {
         AtomicBoolean jdksDirectoryConfigured = new AtomicBoolean(false);
         getJavaVersionToJdkDistros().get().forEach((javaVersion, jdkDistros) -> {
             jdkDistros.forEach(jdkDistribution -> {
-                if (!getIncludeOnlyCurrentOsArch().get()
-                        || (jdkDistribution.getOs().get().equals(os)
-                                && jdkDistribution.getArch().get().equals(arch))) {
-                    Path outputDir = gradleJdksDir
-                            .resolve(javaVersion.toString())
-                            .resolve(jdkDistribution.getOs().get().uiName())
-                            .resolve(jdkDistribution.getArch().get().uiName());
-                    Path downloadUrlPath = outputDir.resolve("download-url");
-                    Path localPath = outputDir.resolve("local-path");
-                    applyGradleJdkFileAction(downloadUrlPath, localPath, jdkDistribution);
-                    jdksDirectoryConfigured.set(true);
-                }
+                Path outputDir = gradleJdksDir
+                        .resolve(javaVersion.toString())
+                        .resolve(jdkDistribution.getOs().get().uiName())
+                        .resolve(jdkDistribution.getArch().get().uiName());
+                Path downloadUrlPath = outputDir.resolve("download-url");
+                Path localPath = outputDir.resolve("local-path");
+                applyGradleJdkFileAction(downloadUrlPath, localPath, jdkDistribution);
+                jdksDirectoryConfigured.set(true);
             });
         });
         if (!jdksDirectoryConfigured.get()) {

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/SetupJdksTask.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/SetupJdksTask.java
@@ -16,11 +16,14 @@
 
 package com.palantir.gradle.jdks;
 
+import com.palantir.gradle.utils.environmentvariables.EnvironmentVariables;
 import com.palantir.platform.GradleOperatingSystem;
 import com.palantir.platform.OperatingSystem;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Consumer;
 import javax.inject.Inject;
 import org.apache.tools.ant.util.TeeOutputStream;
 import org.gradle.api.DefaultTask;
@@ -42,6 +45,9 @@ public abstract class SetupJdksTask extends DefaultTask {
     private static final Logger logger = Logging.getLogger(SetupJdksTask.class);
 
     @InputFile
+    public abstract RegularFileProperty getGradleJdksSetupScript();
+
+    @InputFile
     public abstract RegularFileProperty getGradlewScript();
 
     @Inject
@@ -50,12 +56,49 @@ public abstract class SetupJdksTask extends DefaultTask {
     @Nested
     protected abstract GradleOperatingSystem getOperatingSystem();
 
+    @Nested
+    abstract EnvironmentVariables getEnvironment();
+
     @TaskAction
     public final void exec() {
         if (getOperatingSystem().getOperatingSystem().get().equals(OperatingSystem.WINDOWS)) {
             logger.debug("Windows gradleJdk setup is not yet supported.");
             return;
         }
+        runCommandWithFailureHandling(
+                List.of(getGradleJdksSetupScript().get().getAsFile().getAbsolutePath()), output -> {
+                    throw new RuntimeException(String.format("The Gradle JDK setup has failed. Error: %s", output));
+                });
+
+        // Running ./gradlew is not compatible with @GradlePluginTests
+        boolean shouldRunGradlew = getEnvironment()
+                .envVarOrFromTestingProperty("palantir.gradle.plugin.tests")
+                .map(value -> !Boolean.parseBoolean(value))
+                .orElse(true)
+                .get();
+
+        if (!shouldRunGradlew) {
+            logger.warn("Skipping `./gradlew javaToolchains` run because running `./gradlew` is not compatible with"
+                    + " @GradlePluginTests.");
+            return;
+        }
+
+        runCommandWithFailureHandling(
+                List.of(getGradlewScript().get().getAsFile().getAbsolutePath(), "-q", "javaToolchains", "--stacktrace"),
+                output -> {
+                    if (output.contains("UnsupportedClassVersionError")) {
+                        throw new RuntimeException(
+                                "The Gradle JDK setup has failed. The Gradle Daemon major version might be"
+                                        + " incorrectly set. Update the Gradle JDK major version using"
+                                        + " `jdks.daemonTargetVersion` in your `build.gradle` and the"
+                                        + " `gradle/gradle-daemon-jdk-version` entry");
+                    }
+                    throw new RuntimeException(String.format(
+                            "Failed to run javaToolchains after setting up the JDK setup. Error: %s", output));
+                });
+    }
+
+    private void runCommandWithFailureHandling(List<String> command, Consumer<String> errorHandler) {
         ByteArrayOutputStream inMemoryOutput = new ByteArrayOutputStream();
         OutputStream logOutput = new TeeOutputStream(System.out, inMemoryOutput);
 
@@ -63,18 +106,10 @@ public abstract class SetupJdksTask extends DefaultTask {
             execSpec.setIgnoreExitValue(true);
             execSpec.setStandardOutput(logOutput);
             execSpec.setErrorOutput(logOutput);
-            execSpec.commandLine(getGradlewScript().get().getAsFile().toPath(), "-q", "javaToolchains", "--stacktrace");
+            execSpec.commandLine(command);
         });
-
         if (execResult.getExitValue() != 0) {
-            String output = inMemoryOutput.toString(StandardCharsets.UTF_8);
-            if (output.contains("UnsupportedClassVersionError")) {
-                throw new RuntimeException(
-                        "The Gradle JDK setup has failed. The Gradle Daemon major version might be incorrectly set."
-                                + " Update the Gradle JDK major version using `jdks.daemonTargetVersion` in your"
-                                + " `build.gradle` and the `gradle/gradle-daemon-jdk-version` entry");
-            }
-            throw new RuntimeException(String.format("The Gradle JDK setup has failed. Error: %s", output));
+            errorHandler.accept(inMemoryOutput.toString(StandardCharsets.UTF_8));
         }
     }
 }

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java
@@ -175,8 +175,15 @@ public abstract class ToolchainsPlugin implements Plugin<Project> {
         rootProject.getTasks().register("setupJdks", SetupJdksTask.class, setupJdksTask -> {
             setupJdksTask.setDescription("Configures the gradle JDK setup.");
             setupJdksTask.setGroup(GRADLE_JDK_GROUP);
-            setupJdksTask.getGradlewScript().set(wrapperPatcherTask.get().getPatchedGradlewScript());
-            setupJdksTask.dependsOn(generateGradleJdkConfigs, wrapperPatcherTask);
+            setupJdksTask
+                    .getGradleJdksSetupScript()
+                    .fileProvider(generateGradleJdkConfigs.map(task -> task.getOutputGradleDirectory()
+                            .file("gradle-jdks-setup.sh")
+                            .get()
+                            .getAsFile()));
+            setupJdksTask.getGradlewScript().fileProvider(wrapperPatcherTask.map(task -> task.getPatchedGradlewScript()
+                    .get()
+                    .getAsFile()));
         });
 
         rootProject.getTasks().named("javaToolchains").configure(task -> {

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkToolchainsIntegrationTest.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/GradleJdkToolchainsIntegrationTest.groovy
@@ -109,30 +109,6 @@ class GradleJdkToolchainsIntegrationTest extends GradleJdkIntegrationSpec {
         gradleVersionNumber << GRADLE_TEST_VERSIONS
     }
 
-    def '#gradleVersionNumber: generates only the files for the current arch & os'() {
-        gradleVersion = gradleVersionNumber
-        setupJdksHardcodedVersions()
-        applyApplicationPlugin()
-
-        when:
-        file('gradle.properties') << 'palantir.jdk.setup.enabled=true'
-        runTasksSuccessfully("generateGradleJdkConfigs", "--onlyForCurrentOsArch")
-
-        then: 'generates directories only for the current Os & Arch'
-        String os = OperatingSystem.get().uiName()
-        String arch = CurrentArch.get().uiName()
-        try (Stream<Path> paths = Files.find(projectDir.toPath().resolve("gradle/jdks"),
-                4,
-                (path, attr) -> path.getFileName().toString().equals("local-path") && attr.isRegularFile())) {
-            assertThat(paths.map{it -> projectDir.toPath().relativize(it).toString()}.collect(Collectors.toSet()))
-                    .isEqualTo(Stream.of("11", "17", "21").map {it -> String.format("gradle/jdks/%s/%s/%s/local-path", it,os, arch) }.collect(Collectors.toSet()))
-        }
-
-        where:
-        gradleVersionNumber << GRADLE_TEST_VERSIONS
-    }
-
-
     def '#gradleVersionNumber: javaToolchains correctly set-up with baseline-java'() {
         gradleVersion = gradleVersionNumber
         setupJdksHardcodedVersions()

--- a/versions.lock
+++ b/versions.lock
@@ -30,6 +30,8 @@ com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions:1.9.0 (2 c
 
 com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.3.0 (1 constraints: 0505f435)
 
+com.palantir.gradle.utils:environment-variables:0.15.0 (1 constraints: 3805323b)
+
 com.palantir.gradle.utils:lazily-configured-mapping:0.15.0 (2 constraints: f116383a)
 
 com.palantir.gradle.utils:platform:0.15.0 (1 constraints: 3805323b)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
- Removed the `onlyForCurrentOsArch` flag introduced in https://github.com/palantir/gradle-jdks/pull/626. I ended up not needing it anymore in the GradlePluginTests integration. 
- SetupJdks task will not run `./gradlew javaToolchains` for @GradlePluginTests integrations. Running ./gradlew is not compatible with how we are configuring the gradle plugins in the new test framework. [internal](https://pl.ntr/2Dl) discussion here. issue seen when running `./gradlew` in `@GradlePluginTests`: 

```
  * Exception is:
  org.gradle.api.plugins.UnknownPluginException: Plugin [id: 'com.palantir.jdks.settings'] was not found in any of the following sources:
  
  - Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
  - Included Builds (No included builds contain this plugin)
  - Plugin Repositories (plugin dependency must include a version number for this source
```

FLUP PRs: 
- supporting JDK Automanagement setup in `GradlePluginTests` (draft PR [here](https://github.com/palantir/gradle-plugin-testing/pull/334))
- A FLUP PR will update all the tests in this repo to the new testing framework. 

==COMMIT_MSG==
Prepare for GradlePluginTests integration
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

