### PR TITLE
Avoid POSIX permission changes on non-POSIX filesystems

### DIFF
--- a/changelog/@unreleased/pr-658.v2.yml
+++ b/changelog/@unreleased/pr-658.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid UnsupportedOperationException when setting POSIX permissions on non-POSIX filesystems.
+  links:
+  - https://github.com/palantir/gradle-jdks/pull/658

--- a/changelog/@unreleased/windows-posix-perms.yml
+++ b/changelog/@unreleased/windows-posix-perms.yml
@@ -1,2 +1,0 @@
-type: fix
-description: Avoid UnsupportedOperationException when setting POSIX permissions on non-POSIX filesystems.

--- a/changelog/@unreleased/windows-posix-perms.yml
+++ b/changelog/@unreleased/windows-posix-perms.yml
@@ -1,0 +1,2 @@
+type: fix
+description: Avoid UnsupportedOperationException when setting POSIX permissions on non-POSIX filesystems.

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigsUtils.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/GradleJdksConfigsUtils.java
@@ -100,6 +100,9 @@ public final class GradleJdksConfigsUtils {
     }
 
     public static void setExecuteFilePermissions(Path path) {
+        if (!path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            return;
+        }
         try {
             Set<PosixFilePermission> perms = Files.getPosixFilePermissions(path);
             perms.addAll(Set.of(

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/PosixPermissionsWindowsTest.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/PosixPermissionsWindowsTest.groovy
@@ -1,23 +1,49 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.gradle.jdks
 
 import spock.lang.Specification
 import spock.lang.TempDir
-
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 
 class PosixPermissionsWindowsTest extends Specification {
 
     @TempDir Path tempDir
 
-    def 'setExecuteFilePermissions crashes on Windows when POSIX is not supported'() {
+    def 'setExecuteFilePermissions works on both POSIX and non-POSIX filesystems'() {
         given:
         Path p = Files.createFile(tempDir.resolve("x.sh"))
+        boolean isPosixSupported = Files.getFileStore(p).supportsFileAttributeView("posix")
 
         when:
         GradleJdksConfigsUtils.setExecuteFilePermissions(p)
 
         then:
-        thrown(RuntimeException) 
+        noExceptionThrown()
+
+        and:
+        if (isPosixSupported) {
+            def perms = Files.getPosixFilePermissions(p)
+            assert perms.contains(PosixFilePermission.OWNER_EXECUTE)
+            assert perms.contains(PosixFilePermission.GROUP_EXECUTE)
+            assert perms.contains(PosixFilePermission.OTHERS_EXECUTE)
+        } else {
+            assert Files.isExecutable(p) || p.toFile().canExecute()
+        }
     }
 }

--- a/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/PosixPermissionsWindowsTest.groovy
+++ b/gradle-jdks/src/test/groovy/com/palantir/gradle/jdks/PosixPermissionsWindowsTest.groovy
@@ -1,0 +1,23 @@
+package com.palantir.gradle.jdks
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PosixPermissionsWindowsTest extends Specification {
+
+    @TempDir Path tempDir
+
+    def 'setExecuteFilePermissions crashes on Windows when POSIX is not supported'() {
+        given:
+        Path p = Files.createFile(tempDir.resolve("x.sh"))
+
+        when:
+        GradleJdksConfigsUtils.setExecuteFilePermissions(p)
+
+        then:
+        thrown(RuntimeException) 
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
On non-POSIX filesystems (e.g., Windows/NTFS), calling Files.setPosixFilePermissions throws UnsupportedOperationException, which can crash workflows that attempt to set execute permissions.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid UnsupportedOperationException when setting POSIX permissions on non-POSIX filesystems
==COMMIT_MSG==

Guard POSIX permission updates behind a filesystem capability check. On non-POSIX
filesystems the operation is skipped and on POSIX filesystems behavior is unchanged.


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None.
