### PR TITLE
Added custom assertion for JDK directories

### DIFF
--- a/gradle-jdks/src/test/java/com/palantir/gradle/jdks/GradleJdkPatcherIntegrationTest.java
+++ b/gradle-jdks/src/test/java/com/palantir/gradle/jdks/GradleJdkPatcherIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.jdks;
 
+import static com.palantir.gradle.jdks.JdkDirectoriesAssert.assertThatJdkDirectories;
 import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -29,15 +30,7 @@ import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.platform.OperatingSystem;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -112,7 +105,7 @@ class GradleJdkPatcherIntegrationTest {
                     .as("gradlew has exactly one patch footer")
                     .containsOnlyOnce(GradleJdksPatchHelper.PATCH_FOOTER);
 
-            checkJdksVersions(rootProject, Set.of("11", "17", "21"));
+            checkJdksVersions(rootProject, 11, 17, 21);
 
             rootProject
                     .file("gradle/gradle-daemon-jdk-version")
@@ -199,20 +192,14 @@ class GradleJdkPatcherIntegrationTest {
                 .doesNotContain("gradle-jdks-setup.sh");
     }
 
-    private static void checkJdksVersions(RootProject rootProject, Set<String> versions) {
-        try (Stream<Path> paths = Files.list(rootProject.path().resolve("gradle/jdks"))) {
-            Assertions.assertThat(paths.filter(Files::isDirectory)
-                            .map(path -> path.getFileName().toString())
-                            .collect(Collectors.toSet()))
-                    .as("JDK version directories match expected versions")
-                    .isEqualTo(versions);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    private static void checkJdksVersions(RootProject rootProject, int... versions) {
+        assertThatJdkDirectories(rootProject)
+                .as("JDK version directories match expected versions")
+                .containsExactJdks(versions);
 
         String osName = OperatingSystem.get().uiName();
         String archName = CurrentArch.get().uiName();
-        versions.stream().findFirst().ifPresent(version -> {
+        for (int version : versions) {
             rootProject
                     .file("gradle/jdks/" + version + "/" + osName + "/" + archName + "/download-url")
                     .assertThat()
@@ -223,6 +210,6 @@ class GradleJdkPatcherIntegrationTest {
                     .assertThat()
                     .as("local-path file exists for version " + version)
                     .exists();
-        });
+        }
     }
 }

--- a/gradle-jdks/src/test/java/com/palantir/gradle/jdks/GradleJdkPatcherIntegrationTest.java
+++ b/gradle-jdks/src/test/java/com/palantir/gradle/jdks/GradleJdkPatcherIntegrationTest.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.jdks;
 
 import static com.palantir.gradle.jdks.JdkDirectoriesAssert.assertThatJdkDirectories;
 import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.gradle.jdks.setup.JdkSetupFailureException;
@@ -105,7 +106,17 @@ class GradleJdkPatcherIntegrationTest {
                     .as("gradlew has exactly one patch footer")
                     .containsOnlyOnce(GradleJdksPatchHelper.PATCH_FOOTER);
 
-            checkJdksVersions(rootProject, 11, 17, 21);
+            assertThatJdkDirectories(rootProject)
+                    .as("JDK version directories match expected versions")
+                    .containsExactJdks(11, 17, 21)
+                    .allSatisfy(jdk -> {
+                        assertThat(jdk.platformPath(OperatingSystem.get(), CurrentArch.get())
+                                        .resolve("download-url"))
+                                .exists();
+                        assertThat(jdk.platformPath(OperatingSystem.get(), CurrentArch.get())
+                                        .resolve("local-path"))
+                                .exists();
+                    });
 
             rootProject
                     .file("gradle/gradle-daemon-jdk-version")
@@ -190,26 +201,5 @@ class GradleJdkPatcherIntegrationTest {
                 .content()
                 .as("gradlew does not contain reference to setup script")
                 .doesNotContain("gradle-jdks-setup.sh");
-    }
-
-    private static void checkJdksVersions(RootProject rootProject, int... versions) {
-        assertThatJdkDirectories(rootProject)
-                .as("JDK version directories match expected versions")
-                .containsExactJdks(versions);
-
-        String osName = OperatingSystem.get().uiName();
-        String archName = CurrentArch.get().uiName();
-        for (int version : versions) {
-            rootProject
-                    .file("gradle/jdks/" + version + "/" + osName + "/" + archName + "/download-url")
-                    .assertThat()
-                    .as("download-url file exists for version " + version)
-                    .exists();
-            rootProject
-                    .file("gradle/jdks/" + version + "/" + osName + "/" + archName + "/local-path")
-                    .assertThat()
-                    .as("local-path file exists for version " + version)
-                    .exists();
-        }
     }
 }

--- a/gradle-jdks/src/test/java/com/palantir/gradle/jdks/GradleJdkToolchainsIntegrationTest.java
+++ b/gradle-jdks/src/test/java/com/palantir/gradle/jdks/GradleJdkToolchainsIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.jdks;
 
+import static com.palantir.gradle.jdks.JdkDirectoriesAssert.assertThatJdkDirectories;
 import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,13 +38,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -230,7 +227,9 @@ class GradleJdkToolchainsIntegrationTest {
                 .as("java home is set to the daemon jdk configured version")
                 .contains("java.home: " + daemonJvm);
 
-        assertJdkDirectories(rootProject, Set.of("11", "17", "21"), "generates directories for all jdk versions");
+        assertThatJdkDirectories(rootProject)
+                .as("generates directories for all jdk versions")
+                .containsExactJdks(11, 17, 21);
 
         gradle.withArgs("compileJava").buildsSuccessfully();
 
@@ -282,8 +281,9 @@ class GradleJdkToolchainsIntegrationTest {
             """);
 
         gradle.withArgs("compileJava").buildsSuccessfully();
-        assertJdkDirectories(
-                rootProject, Set.of(DAEMON_MAJOR_VERSION_17, "23"), "generates directories for all used jdk versions");
+        assertThatJdkDirectories(rootProject)
+                .as("generates directories for all used jdk versions")
+                .containsExactJdks(17, 23);
 
         File compiledClass = rootProject
                 .buildDir()
@@ -304,7 +304,9 @@ class GradleJdkToolchainsIntegrationTest {
             """);
 
         gradle.withArgs().buildsSuccessfully();
-        assertJdkDirectories(rootProject, Set.of(DAEMON_MAJOR_VERSION_17), "only gradle daemon jdk is generated");
+        assertThatJdkDirectories(rootProject)
+                .as("only gradle daemon jdk is generated")
+                .containsExactJdks(17);
     }
 
     @Test
@@ -318,12 +320,15 @@ class GradleJdkToolchainsIntegrationTest {
             """);
 
         gradle.withArgs("generateGradleJdkConfigs").buildsSuccessfully();
-        assertJdkDirectories(rootProject, Set.of("11", "17"), "generates directories for jdk version == 11, 17");
+        assertThatJdkDirectories(rootProject)
+                .as("generates directories for jdk version == 11, 17")
+                .containsExactJdks(11, 17);
 
         gradle.withArgs("generateGradleJdkConfigs", "--includeVersion=11", "--includeVersion=21")
                 .buildsSuccessfully();
-        assertJdkDirectories(
-                rootProject, Set.of("11", "17", "21"), "generates directories for jdk versions == 11, 17, 21");
+        assertThatJdkDirectories(rootProject)
+                .as("generates directories for jdk versions == 11, 17, 21")
+                .containsExactJdks(11, 17, 21);
 
         InvocationResult failingCheck = gradle.withArgs("check").buildsWithFailure();
         assertThat(failingCheck)
@@ -332,10 +337,14 @@ class GradleJdkToolchainsIntegrationTest {
                 .contains("Unexpected Java versions configured: [21]");
 
         gradle.withArgs("setupJdks", "compileJava").buildsSuccessfully();
-        assertJdkDirectories(rootProject, Set.of("11", DAEMON_MAJOR_VERSION_17), "the extra directory was deleted");
+        assertThatJdkDirectories(rootProject)
+                .as("the extra directory was deleted")
+                .containsExactJdks(11, 17);
 
         gradle.withArgs("generateGradleJdkConfigs", "--includeAllJdks").buildsSuccessfully();
-        assertJdkDirectories(rootProject, Set.of("11", "17", "21"), "generates directories for all jdk versions");
+        assertThatJdkDirectories(rootProject)
+                .as("generates directories for all jdk versions")
+                .containsExactJdks(11, 17, 21);
     }
 
     @Test
@@ -347,7 +356,9 @@ class GradleJdkToolchainsIntegrationTest {
             """);
 
         gradle.withArgs("setupJdks").buildsSuccessfully();
-        assertJdkDirectories(rootProject, Set.of("17", "21"), "only jdkVersionsToUse files are generated");
+        assertThatJdkDirectories(rootProject)
+                .as("only jdkVersionsToUse files are generated")
+                .containsExactJdks(17, 21);
     }
 
     @Test
@@ -372,7 +383,9 @@ class GradleJdkToolchainsIntegrationTest {
         subprojectLib21.mainSourceSet().java().writeClass(getMainJavaCode());
 
         gradle.withArgs().buildsSuccessfully();
-        assertJdkDirectories(rootProject, Set.of("17", "21"), "generates directories for all jdk versions");
+        assertThatJdkDirectories(rootProject)
+                .as("generates directories for all jdk versions")
+                .containsExactJdks(17, 21);
     }
 
     @Test
@@ -401,19 +414,6 @@ class GradleJdkToolchainsIntegrationTest {
                 .hasMessageContaining("Toolchain auto-provisioning is not enabled")
                 .hasMessageContaining(
                         "Gradle JDK Auto-management is enabled but the java versions=[15] are not configured.");
-    }
-
-    private static void assertJdkDirectories(
-            RootProject rootProject, Set<String> expectedVersions, String description) {
-        try (Stream<Path> paths = Files.list(rootProject.path().resolve("gradle/jdks"))) {
-            assertThat(paths.filter(Files::isDirectory)
-                            .map(path -> path.getFileName().toString())
-                            .collect(Collectors.toSet()))
-                    .as(description)
-                    .isEqualTo(expectedVersions);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     private static Pair<Integer, Integer> readBytecodeVersion(File file) {

--- a/gradle-jdks/src/test/java/com/palantir/gradle/jdks/JdkDirectoriesAssert.java
+++ b/gradle-jdks/src/test/java/com/palantir/gradle/jdks/JdkDirectoriesAssert.java
@@ -16,23 +16,36 @@
 
 package com.palantir.gradle.jdks;
 
+import com.palantir.gradle.jdks.setup.common.Arch;
 import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.platform.OperatingSystem;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ObjectAssert;
 
 final class JdkDirectoriesAssert
-        extends AbstractObjectAssert<JdkDirectoriesAssert, Set<JdkDirectoriesAssert.JdkDirectory>> {
+        extends AbstractListAssert<
+                JdkDirectoriesAssert,
+                List<JdkDirectoriesAssert.JdkDirectory>,
+                JdkDirectoriesAssert.JdkDirectory,
+                ObjectAssert<JdkDirectoriesAssert.JdkDirectory>> {
 
-    record JdkDirectory(String version, Path path) {}
+    record JdkDirectory(String version, Path path) {
+        Path platformPath(OperatingSystem os, Arch arch) {
+            return path.resolve(os.uiName()).resolve(arch.uiName());
+        }
+    }
 
-    private JdkDirectoriesAssert(Set<JdkDirectory> actual) {
+    private JdkDirectoriesAssert(List<JdkDirectory> actual) {
         super(actual, JdkDirectoriesAssert.class);
     }
 
@@ -42,9 +55,9 @@ final class JdkDirectoriesAssert
 
     static JdkDirectoriesAssert assertThatJdkDirectories(Path jdksRoot) {
         try (Stream<Path> paths = Files.list(jdksRoot)) {
-            Set<JdkDirectory> directories = paths.filter(Files::isDirectory)
+            List<JdkDirectory> directories = paths.filter(Files::isDirectory)
                     .map(path -> new JdkDirectory(path.getFileName().toString(), path))
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toList());
             return new JdkDirectoriesAssert(directories);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -74,5 +87,17 @@ final class JdkDirectoriesAssert
                     "Expected JDK directories to contain versions %s but found directories: %s", expected, actual);
         }
         return this;
+    }
+
+    @Override
+    protected ObjectAssert<JdkDirectory> toAssert(JdkDirectory value, String description) {
+        return new ObjectAssert<>(value).as(description);
+    }
+
+    @Override
+    protected JdkDirectoriesAssert newAbstractIterableAssert(Iterable<? extends JdkDirectory> iterable) {
+        List<JdkDirectory> list = new ArrayList<>();
+        iterable.forEach(list::add);
+        return new JdkDirectoriesAssert(list);
     }
 }

--- a/gradle-jdks/src/test/java/com/palantir/gradle/jdks/JdkDirectoriesAssert.java
+++ b/gradle-jdks/src/test/java/com/palantir/gradle/jdks/JdkDirectoriesAssert.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+import com.palantir.gradle.testing.project.RootProject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.AbstractObjectAssert;
+
+final class JdkDirectoriesAssert
+        extends AbstractObjectAssert<JdkDirectoriesAssert, Set<JdkDirectoriesAssert.JdkDirectory>> {
+
+    record JdkDirectory(String version, Path path) {}
+
+    private JdkDirectoriesAssert(Set<JdkDirectory> actual) {
+        super(actual, JdkDirectoriesAssert.class);
+    }
+
+    static JdkDirectoriesAssert assertThatJdkDirectories(RootProject rootProject) {
+        return assertThatJdkDirectories(rootProject.path().resolve("gradle/jdks"));
+    }
+
+    static JdkDirectoriesAssert assertThatJdkDirectories(Path jdksRoot) {
+        try (Stream<Path> paths = Files.list(jdksRoot)) {
+            Set<JdkDirectory> directories = paths.filter(Files::isDirectory)
+                    .map(path -> new JdkDirectory(path.getFileName().toString(), path))
+                    .collect(Collectors.toSet());
+            return new JdkDirectoriesAssert(directories);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    JdkDirectoriesAssert containsExactJdks(int... versions) {
+        isNotNull();
+        Set<String> expected =
+                Arrays.stream(versions).mapToObj(Integer::toString).collect(Collectors.toSet());
+        Set<String> actualVersions = actual.stream().map(JdkDirectory::version).collect(Collectors.toSet());
+        if (!actualVersions.equals(expected)) {
+            failWithMessage(
+                    "Expected JDK directories to contain exactly versions %s but found directories: %s",
+                    expected, actual);
+        }
+        return this;
+    }
+
+    JdkDirectoriesAssert containsJdk(int... versions) {
+        isNotNull();
+        Set<String> expected =
+                Arrays.stream(versions).mapToObj(Integer::toString).collect(Collectors.toSet());
+        Set<String> actualVersions = actual.stream().map(JdkDirectory::version).collect(Collectors.toSet());
+        if (!actualVersions.containsAll(expected)) {
+            failWithMessage(
+                    "Expected JDK directories to contain versions %s but found directories: %s", expected, actual);
+        }
+        return this;
+    }
+}

--- a/gradle-jdks/src/test/java/com/palantir/gradle/jdks/JdkDirectoriesAssertTest.java
+++ b/gradle-jdks/src/test/java/com/palantir/gradle/jdks/JdkDirectoriesAssertTest.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.jdks;
+
+import static com.palantir.gradle.jdks.JdkDirectoriesAssert.assertThatJdkDirectories;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JdkDirectoriesAssertTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void passes_when_directories_match_expected_versions() throws IOException {
+        Files.createDirectory(tempDir.resolve("11"));
+        Files.createDirectory(tempDir.resolve("17"));
+
+        assertThatJdkDirectories(tempDir).containsExactJdks(11, 17);
+    }
+
+    @Test
+    void fails_when_directories_do_not_match() throws IOException {
+        Files.createDirectory(tempDir.resolve("11"));
+        Files.createDirectory(tempDir.resolve("17"));
+
+        assertThatThrownBy(() -> assertThatJdkDirectories(tempDir).containsExactJdks(11, 21))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected JDK directories to contain exactly versions")
+                .hasMessageContaining("[11, 21]")
+                .hasMessageContaining("JdkDirectory[version=11")
+                .hasMessageContaining("JdkDirectory[version=17");
+    }
+
+    @Test
+    void ignores_non_directory_files() throws IOException {
+        Files.createDirectory(tempDir.resolve("17"));
+        Files.createFile(tempDir.resolve("README"));
+
+        assertThatJdkDirectories(tempDir).containsExactJdks(17);
+    }
+
+    @Test
+    void works_with_as_description() throws IOException {
+        Files.createDirectory(tempDir.resolve("11"));
+
+        assertThatThrownBy(() -> assertThatJdkDirectories(tempDir)
+                        .as("custom description")
+                        .containsExactJdks(21))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("custom description");
+    }
+
+    @Test
+    void containsJdk_passes_when_subset_present() throws IOException {
+        Files.createDirectory(tempDir.resolve("11"));
+        Files.createDirectory(tempDir.resolve("17"));
+        Files.createDirectory(tempDir.resolve("21"));
+
+        assertThatJdkDirectories(tempDir).containsJdk(11, 17);
+    }
+
+    @Test
+    void containsJdk_fails_when_version_missing() throws IOException {
+        Files.createDirectory(tempDir.resolve("11"));
+        Files.createDirectory(tempDir.resolve("17"));
+
+        assertThatThrownBy(() -> assertThatJdkDirectories(tempDir).containsJdk(11, 21))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected JDK directories to contain versions")
+                .hasMessageContaining("[11, 21]");
+    }
+}


### PR DESCRIPTION
## Before this PR
Assertions declared in methods lose composability and also lose nice fluent descriptions. It also trips up the AI because they do the weird comment on top because as far as it can tell, it's just an arbitrary string you're passing through.

```java
// the extra directory was deleted
assertJdkDirectories(rootProject, Set.of("11", DAEMON_MAJOR_VERSION_17), "the extra directory was deleted");
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

I got claude to generate a `JdkDirectoriesAssert` that encapsulates some of that. It was relatively straightforward to generate and relatively low cost in time and effort, that it feels like a no-brainer to do. Here's how you use it:

```java
assertThatJdkDirectories(rootProject)
                .as("generates directories for jdk version == 11, 17")
                .containsExactJdks(11, 17);
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

