### PR TITLE
Make `JdkManager` a Gradle managed type for Gradle 9 compatibility

### DIFF
--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/BaselineJavaJdksPlugin.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/BaselineJavaJdksPlugin.java
@@ -47,11 +47,11 @@ public abstract class BaselineJavaJdksPlugin implements Plugin<Project> {
 
         rootProject.getPluginManager().apply(BaselineJavaVersions.class);
 
-        JdkDistributions jdkDistributions = new JdkDistributions();
-
-        JdksExtension jdksExtension = JdksPlugin.extension(rootProject, jdkDistributions);
-        JdkManager jdkManager = new JdkManager(
-                jdksExtension.getJdkStorageLocation(), jdkDistributions, new JdkDownloaders(jdksExtension), os);
+        JdksExtension jdksExtension = JdksPlugin.extension(rootProject, new JdkDistributions());
+        JdkManager jdkManager = rootProject
+                .getObjects()
+                .newInstance(
+                        JdkManager.class, jdksExtension.getJdkStorageLocation(), new JdkDownloaders(jdksExtension), os);
 
         rootProject
                 .getExtensions()

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -38,27 +38,37 @@ import java.nio.file.StandardOpenOption;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.Stream;
+import javax.inject.Inject;
 import org.gradle.api.Project;
+import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DuplicatesStrategy;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Provider;
+import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 
-public final class JdkManager {
+public abstract class JdkManager {
 
+    private final JdkDistributions jdkDistributions = new JdkDistributions();
     private final Provider<Directory> storageLocation;
-    private final JdkDistributions jdkDistributions;
     private final JdkDownloaders jdkDownloaders;
     private final OperatingSystem operatingSystem;
 
-    JdkManager(
-            Provider<Directory> storageLocation,
-            JdkDistributions jdkDistributions,
-            JdkDownloaders jdkDownloaders,
-            OperatingSystem operatingSystem) {
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
+
+    @Inject
+    protected abstract ArchiveOperations getArchiveOperations();
+
+    @Inject
+    public JdkManager(
+            Provider<Directory> storageLocation, JdkDownloaders jdkDownloaders, OperatingSystem operatingSystem) {
         this.storageLocation = storageLocation;
-        this.jdkDistributions = jdkDistributions;
         this.jdkDownloaders = jdkDownloaders;
         this.operatingSystem = operatingSystem;
     }
@@ -122,8 +132,8 @@ public final class JdkManager {
                             jdkSpec.release().version(),
                             jdkSpec.consistentShortHash(),
                             temporaryJdkPath);
-            project.copy(copy -> {
-                copy.from(unpackTree(project, jdkPath.extension(), jdkArchive));
+            getFileSystemOperations().copy(copy -> {
+                copy.from(unpackTree(jdkPath.extension(), jdkArchive));
                 copy.into(temporaryJdkPath);
                 copy.setDuplicatesStrategy(DuplicatesStrategy.WARN);
             });
@@ -138,7 +148,7 @@ public final class JdkManager {
                                 jdkSpec.distributionName(),
                                 jdkSpec.release().version(),
                                 jdkSpec.consistentShortHash());
-                addCaCert(project, javaHome, name, caCertFile);
+                addCaCert(javaHome, name, caCertFile);
             });
 
             project.getLogger()
@@ -154,7 +164,7 @@ public final class JdkManager {
         } catch (IOException e) {
             throw new UncheckedIOException("Locking failed", e);
         } finally {
-            project.delete(delete -> {
+            getFileSystemOperations().delete(delete -> {
                 delete.delete(temporaryJdkPath.toFile());
             });
         }
@@ -186,10 +196,10 @@ public final class JdkManager {
         }
     }
 
-    private FileTree unpackTree(Project project, Extension extension, Path path) {
+    private FileTree unpackTree(Extension extension, Path path) {
         return switch (extension) {
-            case ZIP -> project.zipTree(path.toFile());
-            case TARGZ -> project.tarTree(path.toFile());
+            case ZIP -> getArchiveOperations().zipTree(path.toFile());
+            case TARGZ -> getArchiveOperations().tarTree(path.toFile());
         };
     }
 
@@ -211,11 +221,10 @@ public final class JdkManager {
         }
     }
 
-    private void addCaCert(Project project, Path javaHome, String alias, String caCert) {
+    private void addCaCert(Path javaHome, String alias, String caCert) {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-        @SuppressWarnings("for-rollout:deprecation")
-        ExecResult keytoolResult = project.exec(exec -> {
+        ExecResult keytoolResult = getExecOperations().exec(exec -> {
             exec.setCommandLine(
                     Paths.get("bin", SystemTools.keytool(operatingSystem)).toString(),
                     "-import",

--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/JdkManager.java
@@ -73,7 +73,7 @@ public abstract class JdkManager {
         this.operatingSystem = operatingSystem;
     }
 
-    public Path jdk(Project project, JdkSpec jdkSpec) {
+    public final Path jdk(Project project, JdkSpec jdkSpec) {
         Path diskPath = storageLocation
                 .get()
                 .getAsFile()


### PR DESCRIPTION
## Before this PR

`JdkManager` uses deprecated `Project` methods that were [removed in Gradle 9](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html#removal_of_projectexec_projectjavaexec_and_script_level_counterparts):
- `Project.exec()` → removed
- `Project.copy()` → removed
- `Project.zipTree()` / `Project.tarTree()` → removed
- `Project.delete()` → removed

These are replaced by service interfaces (`ExecOperations`, `FileSystemOperations`, `ArchiveOperations`) which Gradle recommends injecting instead.

`JdkManager` was a `final` class that received all dependencies through its constructor, including Gradle services passed from the plugin.

## After this PR

`JdkManager` is now an abstract Gradle managed type:
- Gradle services (`ExecOperations`, `FileSystemOperations`, `ArchiveOperations`) are declared as `@Inject` abstract getter methods, letting Gradle inject them automatically
- `JdkDistributions` is instantiated inside `JdkManager` since it is stateless (`new JdkDistributions()`)
- Non-injectable parameters (`storageLocation`, `jdkDownloaders`, `operatingSystem`) are passed through the `@Inject` constructor
- Created via `ObjectFactory.newInstance()` in `BaselineJavaJdksPlugin`

This makes `JdkManager` compatible with Gradle 9 and follows the Gradle managed type pattern for service injection.

## Possible downsides?

<details>
<summary>LFCR</summary>

LFCR: [Make JdkManager a Gradle managed type for Gradle 9 compatibility](https://github.com/palantir/gradle-jdks/pull/716): Replace deprecated Project.exec/copy/delete methods removed in Gradle 9 with @Inject service operations on a Gradle managed type.

</details>
