### PR TITLE
Do not set build-scans for `javaToolchains` in `setupJdks`

### DIFF
--- a/gradle-jdks/src/main/java/com/palantir/gradle/jdks/SetupJdksTask.java
+++ b/gradle-jdks/src/main/java/com/palantir/gradle/jdks/SetupJdksTask.java
@@ -81,7 +81,13 @@ public abstract class SetupJdksTask extends DefaultTask {
         }
 
         runCommandWithFailureHandling(
-                List.of(getGradlewScript().get().getAsFile().getAbsolutePath(), "-q", "javaToolchains", "--stacktrace"),
+                List.of(
+                        getGradlewScript().get().getAsFile().getAbsolutePath(),
+                        "-q",
+                        "javaToolchains",
+                        "--stacktrace",
+                        // Running with --no-scan to stop Excavator producing scans for this execution
+                        "--no-scan"),
                 output -> {
                     if (output.contains("UnsupportedClassVersionError")) {
                         throw new JdkSetupFailureException(


### PR DESCRIPTION
## Before this PR
We invoke Gradle manually from `setupJdks` - this sends a build scan by default on repos that have our internal build scan plugin applied. When run in Excavator, this means that a build scan is sent, as even though the outer Gradle invocation is run with `--no-build-scan`, this invocation does not have this set or propagated.

## After this PR
==COMMIT_MSG==
Do not set build-scans for `javaToolchains` in `setupJdks`
==COMMIT_MSG==

Avoid sending a scan for this at all.

## Possible downsides?
We will not have the `javaToolchains` info in the Gradle build scan server to help diagnose issues from users.
