### PR TITLE
Install Gradle JDK distributions in parallel

### DIFF
--- a/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
+++ b/gradle-jdks-setup/src/main/resources/gradle-jdks-functions.sh
@@ -117,10 +117,59 @@ is_arch_os_supported() {
   return 0 # true
 }
 
+# Runs in the background (see install_and_setup_jdks), so on failure it writes a message and exits
+# non-zero instead of calling `die`, which deletes the shared TMP_WORK_DIR that sibling jobs use
+install_single_jdk() {
+  distribution_local_path=$1
+  distribution_url=$2
+  scripts_dir=$3
+  jdk_installation_directory="$GRADLE_JDKS_HOME"/"$distribution_local_path"
+
+  in_progress_dir="$TMP_WORK_DIR/$distribution_local_path.in-progress"
+  mkdir -p "$in_progress_dir"
+  cd "$in_progress_dir" || { write "failed to change dir to $in_progress_dir"; exit 1; }
+  if command -v curl > /dev/null 2>&1; then
+    write "Using curl to download $distribution_url"
+    case "$distribution_url" in
+      *.zip)
+        distribution_name=${distribution_url##*/}
+        curl -L -C - "$distribution_url" -o "$distribution_name"
+        tar -xzf "$distribution_name"
+        ;;
+      *)
+        curl -L -C - "$distribution_url" | tar -xzf -
+        ;;
+    esac
+  elif command -v wget > /dev/null 2>&1; then
+    write "Using wget to download $distribution_url"
+    case "$distribution_url" in
+      *.zip)
+        distribution_name=${distribution_url##*/}
+        wget -c "$distribution_url" -O "$distribution_name"
+        tar -xzf "$distribution_name"
+        ;;
+      *)
+        wget -qO- -c "$distribution_url" | tar -xzf -
+        ;;
+    esac
+  else
+    write "ERROR: Neither curl nor wget are installed, Could not set up JAVA_HOME"
+    exit 1
+  fi
+
+  java_home=$(get_java_home "$in_progress_dir")
+  "$java_home"/bin/java -cp "$scripts_dir"/gradle-jdks-setup.jar com.palantir.gradle.jdks.setup.GradleJdkInstallationSetup jdkSetup "$jdk_installation_directory" || { write "Failed to set up JDK $jdk_installation_directory"; exit 1; }
+  write "Successfully installed JDK distribution in $jdk_installation_directory"
+}
+
 install_and_setup_jdks() {
   gradle_dir=$1
   scripts_dir=${2:-"$1"}
 
+  # read_value calls `die` on missing metadata, and `die` deletes the shared TMP_WORK_DIR, so do all
+  # of the die-able work here before any background install job starts
+  jdks_to_install="$TMP_WORK_DIR/jdks-to-install"
+  : > "$jdks_to_install"
   for dir in "$gradle_dir"/jdks/*/; do
     major_version_dir=${dir%*/}
     major_version=${major_version_dir##*/}
@@ -139,42 +188,23 @@ install_and_setup_jdks() {
     else
       continue
     fi
-    # Download and extract the distribution into a temporary directory
-    in_progress_dir="$TMP_WORK_DIR/$distribution_local_path.in-progress"
-    mkdir -p "$in_progress_dir"
-    cd "$in_progress_dir" || die "failed to change dir to $in_progress_dir"
-    if command -v curl > /dev/null 2>&1; then
-      write "Using curl to download $distribution_url"
-      case "$distribution_url" in
-        *.zip)
-          distribution_name=${distribution_url##*/}
-          curl -L -C - "$distribution_url" -o "$distribution_name"
-          tar -xzf "$distribution_name"
-          ;;
-        *)
-          curl -L -C - "$distribution_url" | tar -xzf -
-          ;;
-      esac
-    elif command -v wget > /dev/null 2>&1; then
-      write "Using wget to download $distribution_url"
-      case "$distribution_url" in
-        *.zip)
-          distribution_name=${distribution_url##*/}
-          wget -c "$distribution_url" -O "$distribution_name"
-          tar -xzf "$distribution_name"
-          ;;
-        *)
-          wget -qO- -c "$distribution_url" | tar -xzf -
-          ;;
-      esac
-    else
-      die "ERROR: Neither curl nor wget are installed, Could not set up JAVA_HOME"
-    fi
-    cd - > /dev/null || die "failed to change dir to old pwd: $OLDPWD"
-
-    # Finding the java_home
-    java_home=$(get_java_home "$in_progress_dir")
-    "$java_home"/bin/java -cp "$scripts_dir"/gradle-jdks-setup.jar com.palantir.gradle.jdks.setup.GradleJdkInstallationSetup jdkSetup "$jdk_installation_directory" || die "Failed to set up JDK $jdk_installation_directory"
-    write "Successfully installed JDK distribution in $jdk_installation_directory"
+    # local-path and download-url never contain whitespace
+    echo "$distribution_local_path $distribution_url" >> "$jdks_to_install"
   done
+
+  jdk_install_pids=""
+  while read -r distribution_local_path distribution_url; do
+    install_single_jdk "$distribution_local_path" "$distribution_url" "$scripts_dir" &
+    jdk_install_pids="$jdk_install_pids $!"
+  done < "$jdks_to_install"
+
+  jdk_install_failed=0
+  for jdk_install_pid in $jdk_install_pids; do
+    if ! wait "$jdk_install_pid"; then
+      jdk_install_failed=1
+    fi
+  done
+  if [ "$jdk_install_failed" -ne 0 ]; then
+    die "ERROR: Failed to install one or more Gradle JDK distributions"
+  fi
 }


### PR DESCRIPTION
## Before this PR
`gradle/gradle-jdks-setup.sh` provisions any missing JDK distributions listed under `gradle/jdks` one at a time: each distribution is fully downloaded, extracted, and set up before the next one starts. A project that pins several JDKs (for example a daemon JDK plus separate compile/runtime JDKs) pays the sum of every download serially, which is slow on cold checkouts and on CI where the JDK cache is empty.

## After this PR
Missing JDK distributions are downloaded, extracted, and set up in parallel: the script starts one background job per distribution and waits for all of them before configuring the Gradle daemon JDK. Because setup is dominated by independent network downloads, wall-clock time drops from roughly the sum of the per-JDK downloads to roughly the slowest single download.

Measured on a Linux CI executor provisioning JDK 21 + JDK 25 (download + extract):

| | Time |
| --- | --- |
| Sequential download+extract (current) | ~6.8-7.5s |
| Parallel download+extract | ~3.7s |

Behavior is otherwise unchanged: already-installed JDKs are still skipped, JDK 8 is still ignored, and a failed install still fails the whole setup. Distributions are resolved and filtered serially first (that phase can `die` on missing metadata, which deletes the shared temp dir), and only then installed in parallel, so a failed install never deletes the temp dir out from under an in-flight sibling.

==COMMIT_MSG==
Install Gradle JDK distributions in parallel
==COMMIT_MSG==

## Possible downsides?
Parallel installs raise transient network and disk usage during setup (all distributions download at once instead of sequentially). On a very bandwidth-limited machine an individual download could be slower, though total setup time should still improve.
