### PR TITLE
Do not persist workspace between check and publish in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,6 @@ jobs:
             fi
       - run: ./gradlew --parallel --stacktrace --continue --max-workers=2 check -Porg.gradle.java.installations.fromEnv=JAVA_11_HOME,JAVA_17_HOME,JAVA_21_HOME,JAVA_HOME
       - *check-no-files-changed
-      - persist_to_workspace:
-          root: /home/circleci
-          paths: [ project ]
       - save_cache:
           key: 'gradle-wrapper-v1-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
           paths: [ ~/.gradle/wrapper ]
@@ -122,7 +119,31 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.workers.max=1 -Dorg.gradle.jvmargs='-Xmx2147483648 --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED'
       _JAVA_OPTIONS: -XX:ActiveProcessorCount=2 -XX:MaxRAM=4g -XX:+CrashOnOutOfMemoryError -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
-      - attach_workspace: { at: /home/circleci }
+      - checkout
+      - run:
+          name: delete_unrelated_tags
+          command: |
+            ALL_TAGS=$(git tag --points-at HEAD)
+
+            if [ -z "$ALL_TAGS" ]; then
+                echo "No-op as there are no tags on the current commit ($(git rev-parse HEAD))"
+                exit 0
+            fi
+
+            if [ -z "${CIRCLE_TAG:+x}" ]; then
+                echo "Non-tag build, deleting all tags which point to HEAD: [${ALL_TAGS/$'\n'/,}]"
+                echo "$ALL_TAGS" | while read -r TAG; do git tag -d "$TAG" 1>/dev/null; done
+                exit 0
+            fi
+
+            TAGS_TO_DELETE=$(echo "$ALL_TAGS" | grep -v "^$CIRCLE_TAG$" || :)
+            if [ -z "$TAGS_TO_DELETE" ]; then
+                echo "No-op as exactly one tag ($CIRCLE_TAG) points to HEAD"
+                exit 0
+            fi
+
+            echo "Detected tag build, deleting all tags except '$CIRCLE_TAG' which point to HEAD: [${TAGS_TO_DELETE/$'\n'/,}]"
+            echo "$TAGS_TO_DELETE" | while read -r TAG; do git tag -d "$TAG" 1>/dev/null; done
       - restore_cache: { key: 'gradle-wrapper-v1-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
       - restore_cache: { key: 'publish-gradle-cache-v1-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
       - run:

--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -2,3 +2,4 @@
 export CIRCLECI_TEMPLATE=java-library-oss
 export JDK=11
 export DOCKER_TESTS=true
+export PERSIST_WORKSPACE_BETWEEN_CHECK_AND_PUBLISH=false


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The persisting to workspace step was taking ~1.5x the time it took to actually perform the check. Example CI run: https://app.circleci.com/pipelines/github/palantir/gradle-jdks/4665/workflows/37b0f310-f865-4e9a-bc4f-c00ee65698bc/jobs/13815

Here we see the check step taking ~7.5 minutes whereas the persist step takes ~11.5 minutes. In this case, the persisted workspace wasn't even consumed afterwards, since this was simply an intermediate commit as part of a PR and not as part of a release.
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Set `PERSIST_WORKSPACE_BETWEEN_CHECK_AND_PUBLISH` to `false`. In the worst case during publish, it will have to recreate the artifacts that were stored in the cache. The time taken to do a cold checkout + build during the publish step in CI is yet to be measured.
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

